### PR TITLE
Object statistics

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -9,6 +9,7 @@ use Icinga\Module\Icingadb\Common\Links;
 use Icinga\Module\Icingadb\Model\History;
 use Icinga\Module\Icingadb\Model\Host;
 use Icinga\Module\Icingadb\Model\Service;
+use Icinga\Module\Icingadb\Model\ServicestateSummary;
 use Icinga\Module\Icingadb\Web\Controller;
 use Icinga\Module\Icingadb\Widget\Detail\HostDetail;
 use Icinga\Module\Icingadb\Widget\Detail\QuickActions;
@@ -49,6 +50,10 @@ class HostController extends Controller
 
     public function indexAction()
     {
+        $serviceSummary = ServicestateSummary::on($this->getDb())->with('state');
+        $serviceSummary->getSelectBase()
+            ->where(['host_id = ?' => $this->host->id]);
+
         if ($this->host->state->is_overdue) {
             $this->controls->addAttributes(['class' => 'overdue']);
         }
@@ -56,7 +61,7 @@ class HostController extends Controller
         $this->addControl((new HostList([$this->host]))->setViewMode('minimal'));
         $this->addControl(new QuickActions($this->host));
 
-        $this->addContent(new HostDetail($this->host));
+        $this->addContent(new HostDetail($this->host, $serviceSummary->first()));
 
         $this->setAutorefreshInterval(10);
     }

--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -10,7 +10,7 @@ use Icinga\Module\Icingadb\Model\History;
 use Icinga\Module\Icingadb\Model\Host;
 use Icinga\Module\Icingadb\Model\Service;
 use Icinga\Module\Icingadb\Web\Controller;
-use Icinga\Module\Icingadb\Widget\Detail\ObjectDetail;
+use Icinga\Module\Icingadb\Widget\Detail\HostDetail;
 use Icinga\Module\Icingadb\Widget\Detail\QuickActions;
 use Icinga\Module\Icingadb\Widget\DowntimeList;
 use Icinga\Module\Icingadb\Widget\HostList;
@@ -18,7 +18,6 @@ use Icinga\Module\Icingadb\Widget\ItemList\CommentList;
 use Icinga\Module\Icingadb\Widget\ItemList\HistoryList;
 use Icinga\Module\Icingadb\Widget\ServiceList;
 use Icinga\Module\Icingadb\Widget\ShowMore;
-use ipl\Web\Url;
 
 class HostController extends Controller
 {
@@ -57,7 +56,7 @@ class HostController extends Controller
         $this->addControl((new HostList([$this->host]))->setViewMode('minimal'));
         $this->addControl(new QuickActions($this->host));
 
-        $this->addContent(new ObjectDetail($this->host));
+        $this->addContent(new HostDetail($this->host));
 
         $this->setAutorefreshInterval(10);
     }

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -9,15 +9,14 @@ use Icinga\Module\Icingadb\Common\ServiceLinks;
 use Icinga\Module\Icingadb\Model\History;
 use Icinga\Module\Icingadb\Model\Service;
 use Icinga\Module\Icingadb\Web\Controller;
-use Icinga\Module\Icingadb\Widget\Detail\ObjectDetail;
 use Icinga\Module\Icingadb\Widget\Detail\QuickActions;
+use Icinga\Module\Icingadb\Widget\Detail\ServiceDetail;
 use Icinga\Module\Icingadb\Widget\DowntimeList;
 use Icinga\Module\Icingadb\Widget\ItemList\CommentList;
 use Icinga\Module\Icingadb\Widget\ItemList\HistoryList;
 use Icinga\Module\Icingadb\Widget\ServiceList;
 use Icinga\Module\Icingadb\Widget\ShowMore;
 use ipl\Sql\Sql;
-use ipl\Web\Url;
 
 class ServiceController extends Controller
 {
@@ -61,7 +60,7 @@ class ServiceController extends Controller
         $this->addControl((new ServiceList([$this->service]))->setViewMode('minimal'));
         $this->addControl(new QuickActions($this->service));
 
-        $this->addContent(new ObjectDetail($this->service));
+        $this->addContent(new ServiceDetail($this->service));
 
         $this->setAutorefreshInterval(10);
     }

--- a/library/Icingadb/Widget/Detail/HostDetail.php
+++ b/library/Icingadb/Widget/Detail/HostDetail.php
@@ -2,8 +2,36 @@
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 
+use Icinga\Data\Filter\Filter;
+use Icinga\Module\Icingadb\Widget\EmptyState;
+use Icinga\Module\Icingadb\Widget\HorizontalKeyValue;
+use ipl\Html\Html;
+
 class HostDetail extends ObjectDetail
 {
+    protected $serviceSummary;
+
+    public function __construct($object, $serviceSummary)
+    {
+        parent::__construct($object);
+
+        $this->serviceSummary = $serviceSummary;
+    }
+
+    protected function createServiceStatistics()
+    {
+        if ($this->serviceSummary->services_total > 0) {
+            $services = new ServiceStatistics($this->serviceSummary);
+            $services->setBaseFilter(Filter::where('host.name', $this->object->name));
+        } else {
+            $services = new EmptyState(mt('icingadb', 'This host has no services'));
+        }
+
+        $stats = [Html::tag('h2', mt('icingadb', 'Services'))];
+        $stats[] = new HorizontalKeyValue(mt('icingadb', 'Services'), $services);
+        return $stats;
+    }
+
     protected function assemble()
     {
         $this->add([
@@ -11,6 +39,7 @@ class HostDetail extends ObjectDetail
             $this->createEvents(),
             $this->createActions(),
             $this->createNotes(),
+            $this->createServiceStatistics(),
             $this->createGroups(),
             $this->createComments(),
             $this->createDowntimes(),

--- a/library/Icingadb/Widget/Detail/HostDetail.php
+++ b/library/Icingadb/Widget/Detail/HostDetail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Icinga\Module\Icingadb\Widget\Detail;
+
+class HostDetail extends ObjectDetail
+{
+    protected function assemble()
+    {
+        $this->add([
+            $this->createPluginOutput(),
+            $this->createEvents(),
+            $this->createActions(),
+            $this->createNotes(),
+            $this->createGroups(),
+            $this->createComments(),
+            $this->createDowntimes(),
+            $this->createNotifications(),
+            $this->createCheckStatistics(),
+            $this->createPerformanceData(),
+            $this->createCustomVars(),
+            $this->createFeatureToggles()
+        ]);
+    }
+}

--- a/library/Icingadb/Widget/Detail/HostStatistics.php
+++ b/library/Icingadb/Widget/Detail/HostStatistics.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Icinga\Module\Icingadb\Widget\Detail;
+
+use Icinga\Chart\Donut;
+use Icinga\Module\Icingadb\Common\Links;
+use Icinga\Module\Icingadb\Widget\HostStateBadges;
+use Icinga\Module\Icingadb\Widget\VerticalKeyValue;
+use ipl\Html\HtmlString;
+use ipl\Web\Widget\Link;
+
+class HostStatistics extends ObjectStatistics
+{
+    protected $summary;
+
+    public function __construct($summary)
+    {
+        $this->summary = $summary;
+    }
+
+    protected function createDonut()
+    {
+        $donut = (new Donut())
+            ->addSlice($this->summary->hosts_up, ['class' => 'slice-state-ok'])
+            ->addSlice($this->summary->hosts_down_handled, ['class' => 'slice-state-critical-handled'])
+            ->addSlice($this->summary->hosts_down_unhandled, ['class' => 'slice-state-critical'])
+            ->addSlice($this->summary->hosts_pending, ['class' => 'slice-state-pending']);
+
+        return HtmlString::create($donut->render());
+    }
+
+    protected function createTotal()
+    {
+        $url = Links::hosts();
+        if ($this->hasBaseFilter()) {
+            $url->addFilter($this->getBaseFilter());
+        }
+
+        return new Link(
+            new VerticalKeyValue(
+                mtp('icingadb', 'Host', 'Hosts', $this->summary->hosts_total),
+                $this->summary->hosts_total
+            ),
+            $url
+        );
+    }
+
+    protected function createBadges()
+    {
+        $badges = new HostStateBadges($this->summary);
+        if ($this->hasBaseFilter()) {
+            $badges->setBaseFilter($this->getBaseFilter());
+        }
+
+        return $badges;
+    }
+}

--- a/library/Icingadb/Widget/Detail/ObjectDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectDetail.php
@@ -6,11 +6,9 @@ use Icinga\Application\Config;
 use Icinga\Application\Icinga;
 use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\Common\HostLinks;
-use Icinga\Module\Icingadb\Common\HostStates;
 use Icinga\Module\Icingadb\Common\Icons;
 use Icinga\Module\Icingadb\Common\Links;
 use Icinga\Module\Icingadb\Common\ServiceLinks;
-use Icinga\Module\Icingadb\Common\ServiceStates;
 use Icinga\Module\Icingadb\Compat\CompatBackend;
 use Icinga\Module\Icingadb\Compat\CompatHost;
 use Icinga\Module\Icingadb\Compat\CompatObject;
@@ -356,23 +354,5 @@ class ObjectDetail extends BaseHtmlElement
         }
 
         return [$users, $usergroups];
-    }
-
-    protected function assemble()
-    {
-        $this->add([
-            $this->createPluginOutput(),
-            $this->createEvents(),
-            $this->createActions(),
-            $this->createNotes(),
-            $this->createGroups(),
-            $this->createComments(),
-            $this->createDowntimes(),
-            $this->createNotifications(),
-            $this->createCheckStatistics(),
-            $this->createPerformanceData(),
-            $this->createCustomVars(),
-            $this->createFeatureToggles()
-        ]);
     }
 }

--- a/library/Icingadb/Widget/Detail/ObjectStatistics.php
+++ b/library/Icingadb/Widget/Detail/ObjectStatistics.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Icinga\Module\Icingadb\Widget\Detail;
+
+use Icinga\Module\Icingadb\Common\BaseFilter;
+use ipl\Html\BaseHtmlElement;
+use ipl\Html\Html;
+
+abstract class ObjectStatistics extends BaseHtmlElement
+{
+    use BaseFilter;
+
+    protected $tag = 'ul';
+
+    protected $defaultAttributes = ['class' => 'object-statistics'];
+
+    abstract protected function createDonut();
+
+    abstract protected function createTotal();
+
+    abstract protected function createBadges();
+
+    protected function assemble()
+    {
+        $this->add([
+            Html::tag('li', ['class' => 'object-statistics-graph'], $this->createDonut()),
+            Html::tag('li', ['class' => ['object-statistics-total', 'text-center']], $this->createTotal()),
+            Html::tag('li', $this->createBadges())
+        ]);
+    }
+}

--- a/library/Icingadb/Widget/Detail/ServiceDetail.php
+++ b/library/Icingadb/Widget/Detail/ServiceDetail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Icinga\Module\Icingadb\Widget\Detail;
+
+class ServiceDetail extends ObjectDetail
+{
+    protected function assemble()
+    {
+        $this->add([
+            $this->createPluginOutput(),
+            $this->createEvents(),
+            $this->createActions(),
+            $this->createNotes(),
+            $this->createGroups(),
+            $this->createComments(),
+            $this->createDowntimes(),
+            $this->createNotifications(),
+            $this->createCheckStatistics(),
+            $this->createPerformanceData(),
+            $this->createCustomVars(),
+            $this->createFeatureToggles()
+        ]);
+    }
+}

--- a/library/Icingadb/Widget/Detail/ServiceStatistics.php
+++ b/library/Icingadb/Widget/Detail/ServiceStatistics.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Icinga\Module\Icingadb\Widget\Detail;
+
+use Icinga\Chart\Donut;
+use Icinga\Module\Icingadb\Common\Links;
+use Icinga\Module\Icingadb\Widget\ServiceStateBadges;
+use Icinga\Module\Icingadb\Widget\VerticalKeyValue;
+use ipl\Html\HtmlString;
+use ipl\Web\Widget\Link;
+
+class ServiceStatistics extends ObjectStatistics
+{
+    protected $summary;
+
+    public function __construct($summary)
+    {
+        $this->summary = $summary;
+    }
+
+    protected function createDonut()
+    {
+        $donut = (new Donut())
+            ->addSlice($this->summary->services_ok, ['class' => 'slice-state-ok'])
+            ->addSlice($this->summary->services_warning_handled, ['class' => 'slice-state-warning-handled'])
+            ->addSlice($this->summary->services_warning_unhandled, ['class' => 'slice-state-warning'])
+            ->addSlice($this->summary->services_critical_handled, ['class' => 'slice-state-critical-handled'])
+            ->addSlice($this->summary->services_critical_unhandled, ['class' => 'slice-state-critical'])
+            ->addSlice($this->summary->services_unknown_handled, ['class' => 'slice-state-unknown-handled'])
+            ->addSlice($this->summary->services_unknown_unhandled, ['class' => 'slice-state-unknown'])
+            ->addSlice($this->summary->services_pending, ['class' => 'slice-state-pending']);
+
+        return HtmlString::create($donut->render());
+    }
+
+    protected function createTotal()
+    {
+        $url = Links::services();
+        if ($this->hasBaseFilter()) {
+            $url->addFilter($this->getBaseFilter());
+        }
+
+        return new Link(
+            new VerticalKeyValue(
+                mtp('icingadb', 'Service', 'Services', $this->summary->services_total),
+                $this->summary->services_total
+            ),
+            $url
+        );
+    }
+
+    protected function createBadges()
+    {
+        $badges = new ServiceStateBadges($this->summary);
+        if ($this->hasBaseFilter()) {
+            $badges->setBaseFilter($this->getBaseFilter());
+        }
+
+        return $badges;
+    }
+}

--- a/library/Icingadb/Widget/ItemList/ServicegroupListItem.php
+++ b/library/Icingadb/Widget/ItemList/ServicegroupListItem.php
@@ -2,15 +2,13 @@
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 
-use Icinga\Chart\Donut;
+use Icinga\Data\Filter\Filter;
 use Icinga\Module\Icingadb\Common\BaseTableRowItem;
 use Icinga\Module\Icingadb\Common\Links;
-use Icinga\Module\Icingadb\Widget\ServiceStateBadges;
-use Icinga\Module\Icingadb\Widget\VerticalKeyValue;
+use Icinga\Module\Icingadb\Widget\Detail\ServiceStatistics;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
 use ipl\Html\HtmlDocument;
-use ipl\Html\HtmlString;
 use ipl\Web\Widget\Link;
 
 /** @property ServicegroupList $list */
@@ -19,34 +17,20 @@ class ServicegroupListItem extends BaseTableRowItem
     protected function assembleColumns(HtmlDocument $columns)
     {
         if ($this->item->services_total > 0) {
-            if ($this->list->getViewMode() !== 'minimal') {
-                $servicesChart = (new Donut())
-                    ->addSlice($this->item->services_ok, ['class' => 'slice-state-ok'])
-                    ->addSlice($this->item->services_warning_handled, ['class' => 'slice-state-warning-handled'])
-                    ->addSlice($this->item->services_warning_unhandled, ['class' => 'slice-state-warning'])
-                    ->addSlice($this->item->services_critical_handled, ['class' => 'slice-state-critical-handled'])
-                    ->addSlice($this->item->services_critical_unhandled, ['class' => 'slice-state-critical'])
-                    ->addSlice($this->item->services_unknown_handled, ['class' => 'slice-state-unknown-handled'])
-                    ->addSlice($this->item->services_unknown_unhandled, ['class' => 'slice-state-unknown'])
-                    ->addSlice($this->item->services_pending, ['class' => 'slice-state-pending']);
+            $serviceStats = new ServiceStatistics($this->item);
 
-                $columns->add($this->createColumn(HtmlString::create($servicesChart->render())));
+            $serviceStats->setBaseFilter(Filter::where('servicegroup.name', $this->item->name));
+            if ($this->list->hasBaseFilter()) {
+                $serviceStats->setBaseFilter(
+                    $serviceStats->getBaseFilter()->andFilter($this->list->getBaseFilter())
+                );
             }
 
-            $badges = new ServiceStateBadges($this->item);
-            $badges
-                ->setBaseFilter($this->list->getBaseFilter())
-                ->getUrl()
-                    ->getParams()
-                    ->mergeValues(['servicegroup.name' => $this->item->name]);
-
-            $columns->add([
-                $this->createColumn($badges->createLink(new VerticalKeyValue(
-                    'Service' . ($this->item->services_total > 1 ? 's' : ''),
-                    $this->item->services_total
-                )))->addAttributes(['class' => 'services-total text-center']),
-                $this->createColumn($badges)
-            ]);
+            $columns->addFrom($serviceStats, function (BaseHtmlElement $item) {
+                $item->getAttributes()->add(['class' => 'col']);
+                $item->setTag('div');
+                return $item;
+            });
         }
     }
 

--- a/public/css/lists.less
+++ b/public/css/lists.less
@@ -345,31 +345,6 @@
         margin-right: .5em;
       }
     }
-
-    &.hosts-total a,
-    &.services-total a {
-      line-height: 1;
-      position: relative;
-
-      &:hover:before {
-        .rounded-corners();
-        background-color: @gray-lighter;
-        content: "";
-        display: block;
-        z-index: 1;
-
-        position: absolute;
-        bottom: -.4em;
-        left: -.4em;
-        top: -.4em;
-        right: -.4em;
-      }
-
-      .vertical-key-value {
-        position: relative;
-        z-index: 2;
-      }
-    }
   }
 
   .list-item > *:not(.visual) {
@@ -388,13 +363,6 @@
     display: inline-block;
     content: '\00a0';
     width: 1em;
-  }
-}
-
-.hostgroup-list, .servicegroup-list {
-  .donut-graph {
-    height: 2.25em;
-    width:  2.25em;
   }
 }
 
@@ -423,11 +391,6 @@
 .servicegroup-list.minimal {
   .col {
     padding: 0;
-
-    &.hosts-total,
-    &.services-total {
-      padding-right: .417em;
-    }
   }
 
   .title br {

--- a/public/css/widgets.less
+++ b/public/css/widgets.less
@@ -889,3 +889,46 @@ div.show-more {
   .clearfix();
   float: right;
 }
+
+ul.object-statistics {
+  // Reset defaults
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  display: flex;
+  align-items: center;
+
+  > li:not(:last-child) {
+    margin-right: 1em;
+  }
+}
+
+.object-statistics-graph .donut-graph {
+  height: 2.25em;
+  width:  2.25em;
+}
+
+.object-statistics-total a {
+  line-height: 1;
+  position: relative;
+
+  &:hover:before {
+    .rounded-corners();
+    background-color: @gray-lighter;
+    content: "";
+    display: block;
+    z-index: 1;
+
+    position: absolute;
+    bottom: -.4em;
+    left: -.4em;
+    top: -.4em;
+    right: -.4em;
+  }
+
+  .vertical-key-value {
+    position: relative;
+    z-index: 2;
+  }
+}


### PR DESCRIPTION
The widget as it's used to display service statistics in a host's details:

![Bildschirmfoto von 2020-02-06 15-31-51](https://user-images.githubusercontent.com/16668527/73946207-da026980-48f5-11ea-9783-1829b150f2b4.png)

The same is now used in hostgroup- and servicegroup-list items.

Requires https://github.com/Icinga/ipl-html/pull/25