### PR TITLE
Fix wrong state information

### DIFF
--- a/application/controllers/ServicesController.php
+++ b/application/controllers/ServicesController.php
@@ -105,7 +105,11 @@ class ServicesController extends Controller
 
         $db = $this->getDb();
 
-        $services = Service::on($db)->with('state');
+        $services = Service::on($db)->with([
+            'state',
+            'host',
+            'host.state'
+        ]);
         $summary = ServicestateSummary::on($db)->with(['state']);
 
         $this->filter($services);

--- a/library/Icingadb/Common/HostStates.php
+++ b/library/Icingadb/Common/HostStates.php
@@ -57,18 +57,21 @@ class HostStates
      */
     public static function text($state)
     {
-        switch ((int) $state) {
-            case self::UP:
+        switch (true) {
+            case $state === self::UP:
                 $text = 'up';
                 break;
-            case self::DOWN:
+            case $state === self::DOWN:
                 $text = 'down';
                 break;
-            case self::UNREACHABLE:
+            case $state === self::UNREACHABLE:
                 $text = 'unreachable';
                 break;
-            case self::PENDING:
+            case $state === self::PENDING:
                 $text = 'pending';
+                break;
+            case $state === null:
+                $text = 'not-available';
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Invalid host state %d', $state));
@@ -88,18 +91,21 @@ class HostStates
      */
     public static function translated($state)
     {
-        switch ((int) $state) {
-            case self::UP:
+        switch (true) {
+            case $state === self::UP:
                 $text = mt('icingadb', 'up');
                 break;
-            case self::DOWN:
+            case $state === self::DOWN:
                 $text = mt('icingadb', 'down');
                 break;
-            case self::UNREACHABLE:
+            case $state === self::UNREACHABLE:
                 $text = mt('icingadb', 'unreachable');
                 break;
-            case self::PENDING:
+            case $state === self::PENDING:
                 $text = mt('icingadb', 'pending');
+                break;
+            case $state === null:
+                $text = mt('icingadb', 'not available');
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Invalid host state %d', $state));

--- a/library/Icingadb/Common/ServiceStates.php
+++ b/library/Icingadb/Common/ServiceStates.php
@@ -62,21 +62,24 @@ class ServiceStates
      */
     public static function text($state)
     {
-        switch ((int) $state) {
-            case self::OK:
+        switch (true) {
+            case $state === self::OK:
                 $text = 'ok';
                 break;
-            case self::WARNING:
+            case $state === self::WARNING:
                 $text = 'warning';
                 break;
-            case self::CRITICAL:
+            case $state === self::CRITICAL:
                 $text = 'critical';
                 break;
-            case self::UNKNOWN:
+            case $state === self::UNKNOWN:
                 $text = 'unknown';
                 break;
-            case self::PENDING:
+            case $state === self::PENDING:
                 $text = 'pending';
+                break;
+            case $state === null:
+                $text = 'not-available';
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Invalid service state %d', $state));
@@ -96,21 +99,24 @@ class ServiceStates
      */
     public static function translated($state)
     {
-        switch ((int) $state) {
-            case self::OK:
+        switch (true) {
+            case $state === self::OK:
                 $text = mt('icingadb', 'ok');
                 break;
-            case self::WARNING:
+            case $state === self::WARNING:
                 $text = mt('icingadb', 'warning');
                 break;
-            case self::CRITICAL:
+            case $state === self::CRITICAL:
                 $text = mt('icingadb', 'critical');
                 break;
-            case self::UNKNOWN:
+            case $state === self::UNKNOWN:
                 $text = mt('icingadb', 'unknown');
                 break;
-            case self::PENDING:
+            case $state === self::PENDING:
                 $text = mt('icingadb', 'pending');
+                break;
+            case $state === null:
+                $text = mt('icingadb', 'not available');
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Invalid service state %d', $state));

--- a/library/Icingadb/Model/Hostgroupsummary.php
+++ b/library/Icingadb/Model/Hostgroupsummary.php
@@ -31,7 +31,7 @@ class Hostgroupsummary extends UnionModel
                 'SUM(CASE WHEN host_state = 99 THEN 1 ELSE 0 END)'
             ),
             'hosts_total'                 => new Expression(
-                'SUM(CASE WHEN host_state IS NOT NULL THEN 1 ELSE 0 END)'
+                'SUM(CASE WHEN host_id IS NOT NULL THEN 1 ELSE 0 END)'
             ),
             'hosts_unreachable'           => new Expression(
                 'SUM(CASE WHEN host_state = 2 THEN 1 ELSE 0 END)'
@@ -60,7 +60,7 @@ class Hostgroupsummary extends UnionModel
                 'SUM(CASE WHEN service_state = 99 THEN 1 ELSE 0 END)'
             ),
             'services_total'              => new Expression(
-                'SUM(CASE WHEN service_state IS NOT NULL THEN 1 ELSE 0 END)'
+                'SUM(CASE WHEN service_id IS NOT NULL THEN 1 ELSE 0 END)'
             ),
             'services_unknown_handled'    => new Expression(
                 'SUM(CASE WHEN service_state = 3 AND service_handled = \'y\' THEN 1 ELSE 0 END)'
@@ -101,9 +101,11 @@ class Hostgroupsummary extends UnionModel
                     'hostgroup_id'           => 'hostgroup.id',
                     'hostgroup_name'         => 'hostgroup.name',
                     'hostgroup_display_name' => 'hostgroup.display_name',
+                    'host_id'                => 'host.id',
                     'host_state'             => 'state.soft_state',
                     'host_handled'           => 'state.is_handled',
                     'host_severity'          => 'state.severity',
+                    'service_id'             => new Expression('NULL'),
                     'service_state'          => new Expression('NULL'),
                     'service_handled'        => new Expression('NULL')
                 ]
@@ -114,9 +116,11 @@ class Hostgroupsummary extends UnionModel
                     'hostgroup_id'           => 'hostgroup.id',
                     'hostgroup_name'         => 'hostgroup.name',
                     'hostgroup_display_name' => 'hostgroup.display_name',
+                    'host_id'                => new Expression('NULL'),
                     'host_state'             => new Expression('NULL'),
                     'host_handled'           => new Expression('NULL'),
                     'host_severity'          => new Expression('0'),
+                    'service_id'             => 'service.id',
                     'service_state'          => 'state.soft_state',
                     'service_handled'        => 'state.is_handled'
                 ]

--- a/library/Icingadb/Model/HoststateSummary.php
+++ b/library/Icingadb/Model/HoststateSummary.php
@@ -12,7 +12,7 @@ class HoststateSummary extends Host
             parent::getColumns(),
             [
                 'hosts_acknowledged'            => new Expression(
-                    'SUM(CASE WHEN host_state.is_acknowledged = \'n\' THEN 0 ELSE 1 END)'
+                    'SUM(CASE WHEN host_state.is_acknowledged = \'y\' THEN 1 ELSE 0 END)'
                 ),
                 'hosts_active_checks_enabled'   => new Expression(
                     'SUM(CASE WHEN host.active_checks_enabled = \'y\' THEN 1 ELSE 0 END)'

--- a/library/Icingadb/Model/HoststateSummary.php
+++ b/library/Icingadb/Model/HoststateSummary.php
@@ -45,7 +45,7 @@ class HoststateSummary extends Host
                     . ' AND host_state.is_acknowledged = \'n\' THEN 1 ELSE 0 END)'
                 ),
                 'hosts_total'                   => new Expression(
-                    'SUM(CASE WHEN host_state.soft_state IS NOT NULL THEN 1 ELSE 0 END)'
+                    'SUM(CASE WHEN host.id IS NOT NULL THEN 1 ELSE 0 END)'
                 ),
                 'hosts_unreachable'             => new Expression(
                     'SUM(CASE WHEN host_state.soft_state = 2 THEN 1 ELSE 0 END)'

--- a/library/Icingadb/Model/ServicegroupSummary.php
+++ b/library/Icingadb/Model/ServicegroupSummary.php
@@ -35,7 +35,7 @@ class ServicegroupSummary extends UnionModel
                 'SUM(CASE WHEN service_state = 99 THEN 1 ELSE 0 END)'
             ),
             'services_total'              => new Expression(
-                'SUM(CASE WHEN service_state IS NOT NULL THEN 1 ELSE 0 END)'
+                'SUM(CASE WHEN service_id IS NOT NULL THEN 1 ELSE 0 END)'
             ),
             'services_unknown_handled'    => new Expression(
                 'SUM(CASE WHEN service_state = 3 AND service_handled = \'y\' THEN 1 ELSE 0 END)'
@@ -77,6 +77,7 @@ class ServicegroupSummary extends UnionModel
                     'servicegroup_id'           => 'servicegroup.id',
                     'servicegroup_name'         => 'servicegroup.name',
                     'servicegroup_display_name' => 'servicegroup.display_name',
+                    'service_id'                => 'service.id',
                     'service_state'             => 'state.soft_state',
                     'service_handled'           => 'state.is_handled',
                     'service_severity'          => 'state.severity'

--- a/library/Icingadb/Model/ServicestateSummary.php
+++ b/library/Icingadb/Model/ServicestateSummary.php
@@ -48,7 +48,7 @@ class ServicestateSummary extends Service
                     . ' AND service_state.is_acknowledged = \'n\' THEN 1 ELSE 0 END)'
                 ),
                 'services_total'                   => new Expression(
-                    'SUM(CASE WHEN service_state.soft_state IS NOT NULL THEN 1 ELSE 0 END)'
+                    'SUM(CASE WHEN service.id IS NOT NULL THEN 1 ELSE 0 END)'
                 ),
                 'services_unknown_handled'         => new Expression(
                     'SUM(CASE WHEN service_state.soft_state = 3'

--- a/library/Icingadb/Model/ServicestateSummary.php
+++ b/library/Icingadb/Model/ServicestateSummary.php
@@ -12,7 +12,7 @@ class ServicestateSummary extends Service
             parent::getColumns(),
             [
                 'services_acknowledged'            => new Expression(
-                    'SUM(CASE WHEN service_state.is_acknowledged = \'n\' THEN 0 ELSE 1 END)'
+                    'SUM(CASE WHEN service_state.is_acknowledged = \'y\' THEN 1 ELSE 0 END)'
                 ),
                 'services_active_checks_enabled'   => new Expression(
                     'SUM(CASE WHEN service.active_checks_enabled = \'y\' THEN 1 ELSE 0 END)'

--- a/library/Icingadb/Widget/Detail/CheckStatistics.php
+++ b/library/Icingadb/Widget/Detail/CheckStatistics.php
@@ -77,7 +77,7 @@ class CheckStatistics extends Card
         $markerNext = Html::tag('div', [
             'class' => 'marker next',
             'style' => 'left: ' .  ($hPadding + $durationScale) . '%',
-            'title' => DateFormatter::formatDateTime($nextCheckTime)
+            'title' => $nextCheckTime !== null ? DateFormatter::formatDateTime($nextCheckTime) : null
         ]);
         $markerNow = Html::tag('div', [
             'class' => 'marker now',
@@ -108,7 +108,10 @@ class CheckStatistics extends Card
             ['class' => 'bubble upwards next'],
             $this->object->state->is_overdue
                 ? new VerticalKeyValue('Overdue', new TimeSince($nextCheckTime))
-                : new VerticalKeyValue('Next Check', new TimeUntil($nextCheckTime))
+                : new VerticalKeyValue(
+                    'Next Check',
+                    $nextCheckTime !== null ? new TimeUntil($nextCheckTime) : 'PENDING'
+                )
         );
 
         $intervalLine = Html::tag('hr', ['class' => 'interval-line']);

--- a/library/Icingadb/Widget/StateListItem.php
+++ b/library/Icingadb/Widget/StateListItem.php
@@ -76,11 +76,10 @@ abstract class StateListItem extends BaseListItem
             $since = new TimeSince($this->state->next_update);
             $since->prepend('Overdue ');
             $since->prepend(new Icon(Icons::WARNING));
-        } else {
-            $since = new TimeSince($this->state->last_state_change);
+            return $since;
+        } elseif ($this->state->last_state_change !== null) {
+            return new TimeSince($this->state->last_state_change);
         }
-
-        return $since;
     }
 
     protected function assemble()

--- a/library/Icingadb/Widget/StateListItem.php
+++ b/library/Icingadb/Widget/StateListItem.php
@@ -7,6 +7,7 @@ use Icinga\Module\Icingadb\Compat\CompatPluginOutput;
 use Icinga\Module\Icingadb\Model\State;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
+use ipl\Html\Text;
 use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\StateBall;
 
@@ -29,7 +30,11 @@ abstract class StateListItem extends BaseListItem
 
     protected function assembleCaption(BaseHtmlElement $caption)
     {
-        $caption->add(CompatPluginOutput::getInstance()->render($this->state->output));
+        if ($this->state->soft_state === null && $this->state->output === null) {
+            $caption->add(Text::create(mt('icingadb', 'Waiting for Icinga DB to synchronize the state.')));
+        } else {
+            $caption->add(CompatPluginOutput::getInstance()->render($this->state->output));
+        }
     }
 
     protected function assembleTitle(BaseHtmlElement $title)

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -82,6 +82,11 @@
   float: none;
 }
 
+.state-ball.state-not-available {
+  .ball-solid(@gray-light);
+  .animate(pulse 1.5s infinite both);
+}
+
 .icon-ball {
   .ball();
   .ball-outline(@gray);


### PR DESCRIPTION
In case Icinga DB did not synchronize the state yet, we now show this to the user properly.

![Bildschirmfoto von 2020-02-07 13-30-20](https://user-images.githubusercontent.com/16668527/74029950-26a97b80-49ae-11ea-902c-334a91c02a89.png)

![Bildschirmfoto von 2020-02-07 13-30-42](https://user-images.githubusercontent.com/16668527/74029952-27421200-49ae-11ea-87ad-74b9961019f9.png)

