### PR TITLE
Prevent `.icinga-info` contents from colliding

### DIFF
--- a/public/css/widget/monitoring-health.less
+++ b/public/css/widget/monitoring-health.less
@@ -43,11 +43,7 @@
 
 
   .icinga-info {
-    margin-bottom: -2em;
-
-    .vertical-key-value {
-      margin-bottom: 2em;
-    }
+    gap: 2em 1em;
   }
 
   .col {


### PR DESCRIPTION
The width of the key-value elements varies, so in some cases there's no gap between them. This makes is hard to grasp the information.

![Screenshot 2025-05-28 at 15 39 14](https://github.com/user-attachments/assets/09d25807-93c4-4c29-b3a5-3f87648d56ad)

I added some space between the elements to prevent that.

![Screenshot 2025-05-28 at 15 41 38](https://github.com/user-attachments/assets/dec399a0-d644-4f5b-a848-cffdde6282c8)
