### PR TITLE
Fix the required version string

### DIFF
--- a/library/Icingadb/ProvidedHook/IcingaHealth.php
+++ b/library/Icingadb/ProvidedHook/IcingaHealth.php
@@ -14,7 +14,7 @@ class IcingaHealth extends HealthHook
 {
     use Database;
 
-    public const REQUIRED_ICINGADB_VERSION = '1.4.0';
+    public const REQUIRED_ICINGADB_VERSION = 'v1.4.0';
 
     /** @var Instance */
     protected $instance;


### PR DESCRIPTION
The required version of _Icinga DB_ in _Icinga DB Web_ was given as `1.4.0`, but _Icinga DB_ seems to write `v1.4.0` to the Database.
This commit changes the string in _Icinga DB Web_ and adds the missing `v`.

This should fix #1230.
Alternatively one could change that in _Icinga DB_ I guess.