### PR TITLE
Comment|DowntimeDetail: Use correct filter for removal

### DIFF
--- a/library/Icingadb/Widget/Detail/CommentDetail.php
+++ b/library/Icingadb/Widget/Detail/CommentDetail.php
@@ -110,7 +110,7 @@ class CommentDetail extends BaseHtmlElement
         }
 
         $action = Links::commentsDelete();
-        $action->setFilter(Filter::equal('name', $this->comment->name));
+        $action->setFilter(Filter::equal('comment.name', $this->comment->name));
 
         return (new DeleteCommentForm())
             ->setObjects([$this->comment])

--- a/library/Icingadb/Widget/Detail/DowntimeDetail.php
+++ b/library/Icingadb/Widget/Detail/DowntimeDetail.php
@@ -55,7 +55,7 @@ class DowntimeDetail extends BaseHtmlElement
     protected function createCancelDowntimeForm()
     {
         $action = Links::downtimesDelete();
-        $action->setFilter(Filter::equal('name', $this->downtime->name));
+        $action->setFilter(Filter::equal('downtime.name', $this->downtime->name));
 
         return (new DeleteDowntimeForm())
             ->setObjects([$this->downtime])


### PR DESCRIPTION
Since #1060, comments/delete and downtimes/delete try to use `ObjectAuthorization`'s cache properly and override `CommandAction`'s `isGrantedOnType()`. Though, the filter is applied to the host and service model as a result, and not to the downtime model. This way, downtime filters MUST be absolute, just like filters provided by the search bar. Otherwise `name=downtime-name` will be translated to e.g. `host.name=downtime-name` which obviously cannot match.

fixes #1245