### PR TITLE
Add links to tactical overview headers

### DIFF
--- a/library/Icingadb/Widget/HostSummaryDonut.php
+++ b/library/Icingadb/Widget/HostSummaryDonut.php
@@ -16,7 +16,7 @@ use ipl\Html\Text;
 use ipl\Stdlib\BaseFilter;
 use ipl\Stdlib\Filter;
 use ipl\Web\Common\Card;
-use ipl\Web\Filter\QueryString;
+use ipl\Web\Widget\ActionLink;
 
 class HostSummaryDonut extends Card
 {
@@ -66,12 +66,21 @@ class HostSummaryDonut extends Card
 
     protected function assembleHeader(BaseHtmlElement $header)
     {
+        $filter = Filter::all();
+
+        if ($this->hasBaseFilter()) {
+            $filter->add($this->getBaseFilter());
+        }
+
         $header->addHtml(
             new HtmlElement('h2', null, Text::create(t('Hosts'))),
             new HtmlElement('span', Attributes::create(['class' => 'meta']), TemplateString::create(
-                t('{{#total}}Total{{/total}} %d'),
-                ['total' => new HtmlElement('span')],
-                (int) $this->summary->hosts_total
+                t('{{#total}}Total{{/total}} {{#link}}%d{{/link}}'),
+                [
+                    'total' => new HtmlElement('span'),
+                    'link' => new ActionLink(null, Links::hosts()->setFilter($filter))
+                ],
+                $this->summary->hosts_total
             ))
         );
     }

--- a/library/Icingadb/Widget/ServiceSummaryDonut.php
+++ b/library/Icingadb/Widget/ServiceSummaryDonut.php
@@ -16,6 +16,7 @@ use ipl\Html\Text;
 use ipl\Stdlib\BaseFilter;
 use ipl\Stdlib\Filter;
 use ipl\Web\Common\Card;
+use ipl\Web\Widget\ActionLink;
 
 class ServiceSummaryDonut extends Card
 {
@@ -69,12 +70,21 @@ class ServiceSummaryDonut extends Card
 
     protected function assembleHeader(BaseHtmlElement $header)
     {
+        $filter = Filter::all();
+
+        if ($this->hasBaseFilter()) {
+            $filter->add($this->getBaseFilter());
+        }
+
         $header->addHtml(
             new HtmlElement('h2', null, Text::create(t('Services'))),
             new HtmlElement('span', Attributes::create(['class' => 'meta']), TemplateString::create(
-                t('{{#total}}Total{{/total}} %d'),
-                ['total' => new HtmlElement('span')],
-                (int) $this->summary->services_total
+                t('{{#total}}Total{{/total}} {{#link}}%d{{/link}}'),
+                [
+                    'total' => new HtmlElement('span'),
+                    'link' => new ActionLink(null, Links::services()->setFilter($filter))
+                ],
+                $this->summary->services_total
             ))
         );
     }

--- a/public/css/widget/donut-container.less
+++ b/public/css/widget/donut-container.less
@@ -1,6 +1,17 @@
 .donut-container {
   .card();
 
+  .card-header > .meta {
+    > span {
+      color: @text-color-light;
+    }
+
+    > .action-link {
+      font-weight: bold;
+      font-size: 1.1em;
+    }
+  }
+
   h2 {
     margin: 0;
   }


### PR DESCRIPTION
Add links on the tactical overview chart headers that open the lists that the donut charts represents considering the active filters.

Closes #820