### PR TITLE
Require Icinga Web 2.12 as minimum now

### DIFF
--- a/doc/02-Installation.md.d/From-Source.md
+++ b/doc/02-Installation.md.d/From-Source.md
@@ -10,7 +10,7 @@ Make sure you use `icingadb` as the module name. The following requirements must
 * MySQL or PostgreSQL PDO PHP libraries
 * The following PHP modules must be installed: `cURL`, `dom`, `json`, `libxml`
 * [Icinga DB](https://github.com/Icinga/icingadb) (≥1.4)
-* [Icinga Web 2](https://github.com/Icinga/icingaweb2) (≥2.9)
+* [Icinga Web 2](https://github.com/Icinga/icingaweb2) (≥2.12)
 * [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥0.17.1)
 * [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (≥0.13)
 

--- a/doc/05-Upgrading.md
+++ b/doc/05-Upgrading.md
@@ -5,6 +5,10 @@ If you are upgrading across multiple versions, make sure to follow the steps for
 
 ## Upgrading to Icinga DB Web v1.3
 
+**Requirements**
+
+* The minimum required Icinga Web version is now 2.12.
+
 **Removed Features**
 
 * The routes `users`, `user`, `usergroup` and `usergroups` have been removed.

--- a/public/css/widget/custom-var-table.less
+++ b/public/css/widget/custom-var-table.less
@@ -37,8 +37,7 @@
     }
   }
 
-  &.can-collapse thead th > span, // Icinga Web 2 < 2.12
-  &[data-can-collapse] thead th > span { // >= 2.12
+  &[data-can-collapse] thead th > span {
     :nth-child(1) {
       display: none;
     }


### PR DESCRIPTION
We were somewhat *compatible* with 2.9. Though, our packages never allowed to install Icinga Web < 2.12 together with Icinga DB Web >= 1.2. The latter requires PHP 8.2 as a minimum and only Icinga Web 2.12 is compatible with it. It's now time to hard require Icinga Web 2.12, althoug you might argue that we should have done that already with v1.2…