### PR TITLE
Upgrade license from GPLv2 to GPLv2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ are easily accomplished with the `Continue With` control that operates on filter
 ## License
 
 Icinga DB Web and the Icinga DB Web documentation are licensed under the terms of the
-[GNU General Public License Version 2](LICENSE).
+[GNU General Public License Version 2](LICENSE) or later.

--- a/application/clicommands/MigrateCommand.php
+++ b/application/clicommands/MigrateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Clicommands;
 

--- a/application/controllers/CommandTransportController.php
+++ b/application/controllers/CommandTransportController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/CommentController.php
+++ b/application/controllers/CommentController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/CommentsController.php
+++ b/application/controllers/CommentsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ContactController.php
+++ b/application/controllers/ContactController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ContactgroupController.php
+++ b/application/controllers/ContactgroupController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ContactgroupsController.php
+++ b/application/controllers/ContactgroupsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ContactsController.php
+++ b/application/controllers/ContactsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/DowntimeController.php
+++ b/application/controllers/DowntimeController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/DowntimesController.php
+++ b/application/controllers/DowntimesController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ErrorController.php
+++ b/application/controllers/ErrorController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/EventController.php
+++ b/application/controllers/EventController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/HealthController.php
+++ b/application/controllers/HealthController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/HistoryController.php
+++ b/application/controllers/HistoryController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/HostgroupController.php
+++ b/application/controllers/HostgroupController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/HostgroupsController.php
+++ b/application/controllers/HostgroupsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/HostsController.php
+++ b/application/controllers/HostsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/NotificationsController.php
+++ b/application/controllers/NotificationsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/RedundancygroupController.php
+++ b/application/controllers/RedundancygroupController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ServicegroupController.php
+++ b/application/controllers/ServicegroupController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ServicegroupsController.php
+++ b/application/controllers/ServicegroupsController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/ServicesController.php
+++ b/application/controllers/ServicesController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/SuggestController.php
+++ b/application/controllers/SuggestController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/controllers/TacticalController.php
+++ b/application/controllers/TacticalController.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Controllers;
 

--- a/application/forms/ApiTransportForm.php
+++ b/application/forms/ApiTransportForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms;
 

--- a/application/forms/Command/CommandForm.php
+++ b/application/forms/Command/CommandForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command;
 

--- a/application/forms/Command/Instance/ToggleInstanceFeaturesForm.php
+++ b/application/forms/Command/Instance/ToggleInstanceFeaturesForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Instance;
 

--- a/application/forms/Command/Object/AcknowledgeProblemForm.php
+++ b/application/forms/Command/Object/AcknowledgeProblemForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/AddCommentForm.php
+++ b/application/forms/Command/Object/AddCommentForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/CheckNowForm.php
+++ b/application/forms/Command/Object/CheckNowForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/DeleteCommentForm.php
+++ b/application/forms/Command/Object/DeleteCommentForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/DeleteDowntimeForm.php
+++ b/application/forms/Command/Object/DeleteDowntimeForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/ProcessCheckResultForm.php
+++ b/application/forms/Command/Object/ProcessCheckResultForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/RemoveAcknowledgementForm.php
+++ b/application/forms/Command/Object/RemoveAcknowledgementForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/ScheduleCheckForm.php
+++ b/application/forms/Command/Object/ScheduleCheckForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/ScheduleHostDowntimeForm.php
+++ b/application/forms/Command/Object/ScheduleHostDowntimeForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/ScheduleServiceDowntimeForm.php
+++ b/application/forms/Command/Object/ScheduleServiceDowntimeForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/SendCustomNotificationForm.php
+++ b/application/forms/Command/Object/SendCustomNotificationForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/Command/Object/ToggleObjectFeaturesForm.php
+++ b/application/forms/Command/Object/ToggleObjectFeaturesForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Command\Object;
 

--- a/application/forms/DatabaseConfigForm.php
+++ b/application/forms/DatabaseConfigForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms;
 

--- a/application/forms/Navigation/ActionForm.php
+++ b/application/forms/Navigation/ActionForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Navigation;
 

--- a/application/forms/Navigation/IcingadbHostActionForm.php
+++ b/application/forms/Navigation/IcingadbHostActionForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Navigation;
 

--- a/application/forms/Navigation/IcingadbServiceActionForm.php
+++ b/application/forms/Navigation/IcingadbServiceActionForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms\Navigation;
 

--- a/application/forms/RedisConfigForm.php
+++ b/application/forms/RedisConfigForm.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Forms;
 

--- a/configuration.php
+++ b/configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb {
 

--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -62,4 +62,4 @@ To install Icinga DB Web see [Installation](02-Installation.md).
 ## License
 
 Icinga DB Web and the Icinga DB Web documentation are licensed under the terms of the
-GNU General Public License Version 2.
+GNU General Public License Version 2 or later.

--- a/library/Icingadb/Authentication/ObjectAuthorization.php
+++ b/library/Icingadb/Authentication/ObjectAuthorization.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Authentication;
 

--- a/library/Icingadb/Command/IcingaApiCommand.php
+++ b/library/Icingadb/Command/IcingaApiCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command;
 

--- a/library/Icingadb/Command/IcingaCommand.php
+++ b/library/Icingadb/Command/IcingaCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command;
 

--- a/library/Icingadb/Command/Instance/ToggleInstanceFeatureCommand.php
+++ b/library/Icingadb/Command/Instance/ToggleInstanceFeatureCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Instance;
 

--- a/library/Icingadb/Command/Object/AcknowledgeProblemCommand.php
+++ b/library/Icingadb/Command/Object/AcknowledgeProblemCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/AddCommentCommand.php
+++ b/library/Icingadb/Command/Object/AddCommentCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/CommandAuthor.php
+++ b/library/Icingadb/Command/Object/CommandAuthor.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/DeleteCommentCommand.php
+++ b/library/Icingadb/Command/Object/DeleteCommentCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/DeleteDowntimeCommand.php
+++ b/library/Icingadb/Command/Object/DeleteDowntimeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/GetObjectCommand.php
+++ b/library/Icingadb/Command/Object/GetObjectCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ObjectsCommand.php
+++ b/library/Icingadb/Command/Object/ObjectsCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ProcessCheckResultCommand.php
+++ b/library/Icingadb/Command/Object/ProcessCheckResultCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/PropagateHostDowntimeCommand.php
+++ b/library/Icingadb/Command/Object/PropagateHostDowntimeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/RemoveAcknowledgementCommand.php
+++ b/library/Icingadb/Command/Object/RemoveAcknowledgementCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ScheduleCheckCommand.php
+++ b/library/Icingadb/Command/Object/ScheduleCheckCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ScheduleDowntimeCommand.php
+++ b/library/Icingadb/Command/Object/ScheduleDowntimeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ScheduleHostDowntimeCommand.php
+++ b/library/Icingadb/Command/Object/ScheduleHostDowntimeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ScheduleServiceDowntimeCommand.php
+++ b/library/Icingadb/Command/Object/ScheduleServiceDowntimeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/SendCustomNotificationCommand.php
+++ b/library/Icingadb/Command/Object/SendCustomNotificationCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/ToggleObjectFeatureCommand.php
+++ b/library/Icingadb/Command/Object/ToggleObjectFeatureCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Object/WithCommentCommand.php
+++ b/library/Icingadb/Command/Object/WithCommentCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Object;
 

--- a/library/Icingadb/Command/Renderer/IcingaApiCommandRenderer.php
+++ b/library/Icingadb/Command/Renderer/IcingaApiCommandRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Renderer;
 

--- a/library/Icingadb/Command/Renderer/IcingaCommandRendererInterface.php
+++ b/library/Icingadb/Command/Renderer/IcingaCommandRendererInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Renderer;
 

--- a/library/Icingadb/Command/Transport/ApiCommandException.php
+++ b/library/Icingadb/Command/Transport/ApiCommandException.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Transport;
 

--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Transport;
 

--- a/library/Icingadb/Command/Transport/CommandTransport.php
+++ b/library/Icingadb/Command/Transport/CommandTransport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Transport;
 

--- a/library/Icingadb/Command/Transport/CommandTransportConfig.php
+++ b/library/Icingadb/Command/Transport/CommandTransportConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Transport;
 

--- a/library/Icingadb/Command/Transport/CommandTransportException.php
+++ b/library/Icingadb/Command/Transport/CommandTransportException.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Transport;
 

--- a/library/Icingadb/Command/Transport/CommandTransportInterface.php
+++ b/library/Icingadb/Command/Transport/CommandTransportInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Command\Transport;
 

--- a/library/Icingadb/Common/Auth.php
+++ b/library/Icingadb/Common/Auth.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/Backend.php
+++ b/library/Icingadb/Common/Backend.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/BaseFilter.php
+++ b/library/Icingadb/Common/BaseFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/BaseStatusBar.php
+++ b/library/Icingadb/Common/BaseStatusBar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/CommandActions.php
+++ b/library/Icingadb/Common/CommandActions.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/Database.php
+++ b/library/Icingadb/Common/Database.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/DetailActions.php
+++ b/library/Icingadb/Common/DetailActions.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/HostLink.php
+++ b/library/Icingadb/Common/HostLink.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/HostLinks.php
+++ b/library/Icingadb/Common/HostLinks.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/HostStates.php
+++ b/library/Icingadb/Common/HostStates.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/IcingaRedis.php
+++ b/library/Icingadb/Common/IcingaRedis.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/Icons.php
+++ b/library/Icingadb/Common/Icons.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/Links.php
+++ b/library/Icingadb/Common/Links.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/LoadMore.php
+++ b/library/Icingadb/Common/LoadMore.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/Macros.php
+++ b/library/Icingadb/Common/Macros.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/Model.php
+++ b/library/Icingadb/Common/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/ObjectInspectionDetail.php
+++ b/library/Icingadb/Common/ObjectInspectionDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/SearchControls.php
+++ b/library/Icingadb/Common/SearchControls.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/ServiceLink.php
+++ b/library/Icingadb/Common/ServiceLink.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/ServiceLinks.php
+++ b/library/Icingadb/Common/ServiceLinks.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/ServiceStates.php
+++ b/library/Icingadb/Common/ServiceStates.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/StateBadges.php
+++ b/library/Icingadb/Common/StateBadges.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Common/TicketLinks.php
+++ b/library/Icingadb/Common/TicketLinks.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Common;
 

--- a/library/Icingadb/Compat/CompatHost.php
+++ b/library/Icingadb/Compat/CompatHost.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Compat;
 

--- a/library/Icingadb/Compat/CompatObject.php
+++ b/library/Icingadb/Compat/CompatObject.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Compat;
 

--- a/library/Icingadb/Compat/CompatService.php
+++ b/library/Icingadb/Compat/CompatService.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Compat;
 

--- a/library/Icingadb/Compat/UrlMigrator.php
+++ b/library/Icingadb/Compat/UrlMigrator.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Compat;
 

--- a/library/Icingadb/Data/CsvResultSet.php
+++ b/library/Icingadb/Data/CsvResultSet.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/CsvResultSetUtils.php
+++ b/library/Icingadb/Data/CsvResultSetUtils.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/DependencyNodes.php
+++ b/library/Icingadb/Data/DependencyNodes.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/JsonResultSet.php
+++ b/library/Icingadb/Data/JsonResultSet.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/JsonResultSetUtils.php
+++ b/library/Icingadb/Data/JsonResultSetUtils.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/PivotTable.php
+++ b/library/Icingadb/Data/PivotTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/VolatileCsvResults.php
+++ b/library/Icingadb/Data/VolatileCsvResults.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Data/VolatileJsonResults.php
+++ b/library/Icingadb/Data/VolatileJsonResults.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Data;
 

--- a/library/Icingadb/Hook/ActionsHook/ObjectActionsHook.php
+++ b/library/Icingadb/Hook/ActionsHook/ObjectActionsHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\ActionsHook;
 

--- a/library/Icingadb/Hook/Common/HookUtils.php
+++ b/library/Icingadb/Hook/Common/HookUtils.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\Common;
 

--- a/library/Icingadb/Hook/Common/TotalSlaReportUtils.php
+++ b/library/Icingadb/Hook/Common/TotalSlaReportUtils.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\Common;
 

--- a/library/Icingadb/Hook/CustomVarRendererHook.php
+++ b/library/Icingadb/Hook/CustomVarRendererHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/EventDetailExtensionHook.php
+++ b/library/Icingadb/Hook/EventDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/ExtensionHook/BaseExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/BaseExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 

--- a/library/Icingadb/Hook/ExtensionHook/ObjectDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/ObjectDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 

--- a/library/Icingadb/Hook/ExtensionHook/ObjectsDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/ObjectsDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 

--- a/library/Icingadb/Hook/HostActionsHook.php
+++ b/library/Icingadb/Hook/HostActionsHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/HostDetailExtensionHook.php
+++ b/library/Icingadb/Hook/HostDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/HostsDetailExtensionHook.php
+++ b/library/Icingadb/Hook/HostsDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/IcingadbSupportHook.php
+++ b/library/Icingadb/Hook/IcingadbSupportHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/PluginOutputHook.php
+++ b/library/Icingadb/Hook/PluginOutputHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/RedundancyGroupDetailExtensionHook.php
+++ b/library/Icingadb/Hook/RedundancyGroupDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/ServiceActionsHook.php
+++ b/library/Icingadb/Hook/ServiceActionsHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/ServiceDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ServiceDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/ServicesDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ServicesDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/TabHook.php
+++ b/library/Icingadb/Hook/TabHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/TabHook/HookActions.php
+++ b/library/Icingadb/Hook/TabHook/HookActions.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook\TabHook;
 

--- a/library/Icingadb/Hook/UserDetailExtensionHook.php
+++ b/library/Icingadb/Hook/UserDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Hook/UsergroupDetailExtensionHook.php
+++ b/library/Icingadb/Hook/UsergroupDetailExtensionHook.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Hook;
 

--- a/library/Icingadb/Model/AcknowledgementHistory.php
+++ b/library/Icingadb/Model/AcknowledgementHistory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ActionUrl.php
+++ b/library/Icingadb/Model/ActionUrl.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Behavior/ActionAndNoteUrl.php
+++ b/library/Icingadb/Model/Behavior/ActionAndNoteUrl.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model\Behavior;
 

--- a/library/Icingadb/Model/Behavior/Bitmask.php
+++ b/library/Icingadb/Model/Behavior/Bitmask.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model\Behavior;
 

--- a/library/Icingadb/Model/Behavior/FlattenedObjectVars.php
+++ b/library/Icingadb/Model/Behavior/FlattenedObjectVars.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model\Behavior;
 

--- a/library/Icingadb/Model/Behavior/HasProblematicParent.php
+++ b/library/Icingadb/Model/Behavior/HasProblematicParent.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model\Behavior;
 

--- a/library/Icingadb/Model/Behavior/ReRoute.php
+++ b/library/Icingadb/Model/Behavior/ReRoute.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model\Behavior;
 

--- a/library/Icingadb/Model/Checkcommand.php
+++ b/library/Icingadb/Model/Checkcommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/CheckcommandArgument.php
+++ b/library/Icingadb/Model/CheckcommandArgument.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/CheckcommandCustomvar.php
+++ b/library/Icingadb/Model/CheckcommandCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/CheckcommandEnvvar.php
+++ b/library/Icingadb/Model/CheckcommandEnvvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Comment.php
+++ b/library/Icingadb/Model/Comment.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/CommentHistory.php
+++ b/library/Icingadb/Model/CommentHistory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Customvar.php
+++ b/library/Icingadb/Model/Customvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/CustomvarFlat.php
+++ b/library/Icingadb/Model/CustomvarFlat.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/DependencyEdge.php
+++ b/library/Icingadb/Model/DependencyEdge.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/DependencyNode.php
+++ b/library/Icingadb/Model/DependencyNode.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Downtime.php
+++ b/library/Icingadb/Model/Downtime.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/DowntimeHistory.php
+++ b/library/Icingadb/Model/DowntimeHistory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Endpoint.php
+++ b/library/Icingadb/Model/Endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Environment.php
+++ b/library/Icingadb/Model/Environment.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Eventcommand.php
+++ b/library/Icingadb/Model/Eventcommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/EventcommandArgument.php
+++ b/library/Icingadb/Model/EventcommandArgument.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/EventcommandCustomvar.php
+++ b/library/Icingadb/Model/EventcommandCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/EventcommandEnvvar.php
+++ b/library/Icingadb/Model/EventcommandEnvvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/FlappingHistory.php
+++ b/library/Icingadb/Model/FlappingHistory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/History.php
+++ b/library/Icingadb/Model/History.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Host.php
+++ b/library/Icingadb/Model/Host.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/HostCustomvar.php
+++ b/library/Icingadb/Model/HostCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/HostState.php
+++ b/library/Icingadb/Model/HostState.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Hostgroup.php
+++ b/library/Icingadb/Model/Hostgroup.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/HostgroupCustomvar.php
+++ b/library/Icingadb/Model/HostgroupCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/HostgroupMember.php
+++ b/library/Icingadb/Model/HostgroupMember.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Hostgroupsummary.php
+++ b/library/Icingadb/Model/Hostgroupsummary.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/HoststateSummary.php
+++ b/library/Icingadb/Model/HoststateSummary.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/IconImage.php
+++ b/library/Icingadb/Model/IconImage.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Instance.php
+++ b/library/Icingadb/Model/Instance.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/LastHostComment.php
+++ b/library/Icingadb/Model/LastHostComment.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/LastServiceComment.php
+++ b/library/Icingadb/Model/LastServiceComment.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotesUrl.php
+++ b/library/Icingadb/Model/NotesUrl.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Notification.php
+++ b/library/Icingadb/Model/Notification.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationCustomvar.php
+++ b/library/Icingadb/Model/NotificationCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationHistory.php
+++ b/library/Icingadb/Model/NotificationHistory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationUser.php
+++ b/library/Icingadb/Model/NotificationUser.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationUsergroup.php
+++ b/library/Icingadb/Model/NotificationUsergroup.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Notificationcommand.php
+++ b/library/Icingadb/Model/Notificationcommand.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationcommandArgument.php
+++ b/library/Icingadb/Model/NotificationcommandArgument.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationcommandCustomvar.php
+++ b/library/Icingadb/Model/NotificationcommandCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/NotificationcommandEnvvar.php
+++ b/library/Icingadb/Model/NotificationcommandEnvvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/RedundancyGroup.php
+++ b/library/Icingadb/Model/RedundancyGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/RedundancyGroupState.php
+++ b/library/Icingadb/Model/RedundancyGroupState.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/RedundancyGroupSummary.php
+++ b/library/Icingadb/Model/RedundancyGroupSummary.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Schema.php
+++ b/library/Icingadb/Model/Schema.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Service.php
+++ b/library/Icingadb/Model/Service.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ServiceCustomvar.php
+++ b/library/Icingadb/Model/ServiceCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ServiceState.php
+++ b/library/Icingadb/Model/ServiceState.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Servicegroup.php
+++ b/library/Icingadb/Model/Servicegroup.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ServicegroupCustomvar.php
+++ b/library/Icingadb/Model/ServicegroupCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ServicegroupMember.php
+++ b/library/Icingadb/Model/ServicegroupMember.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ServicegroupSummary.php
+++ b/library/Icingadb/Model/ServicegroupSummary.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/ServicestateSummary.php
+++ b/library/Icingadb/Model/ServicestateSummary.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/SlaHistoryDowntime.php
+++ b/library/Icingadb/Model/SlaHistoryDowntime.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/SlaHistoryState.php
+++ b/library/Icingadb/Model/SlaHistoryState.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/State.php
+++ b/library/Icingadb/Model/State.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/StateHistory.php
+++ b/library/Icingadb/Model/StateHistory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Timeperiod.php
+++ b/library/Icingadb/Model/Timeperiod.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/TimeperiodCustomvar.php
+++ b/library/Icingadb/Model/TimeperiodCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/TimeperiodOverrideExclude.php
+++ b/library/Icingadb/Model/TimeperiodOverrideExclude.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/TimeperiodOverrideInclude.php
+++ b/library/Icingadb/Model/TimeperiodOverrideInclude.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/TimeperiodRange.php
+++ b/library/Icingadb/Model/TimeperiodRange.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/UnreachableParent.php
+++ b/library/Icingadb/Model/UnreachableParent.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/User.php
+++ b/library/Icingadb/Model/User.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/UserCustomvar.php
+++ b/library/Icingadb/Model/UserCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Usergroup.php
+++ b/library/Icingadb/Model/Usergroup.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/UsergroupCustomvar.php
+++ b/library/Icingadb/Model/UsergroupCustomvar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/UsergroupMember.php
+++ b/library/Icingadb/Model/UsergroupMember.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Vars.php
+++ b/library/Icingadb/Model/Vars.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/Model/Zone.php
+++ b/library/Icingadb/Model/Zone.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Model;
 

--- a/library/Icingadb/ProvidedHook/ApplicationState.php
+++ b/library/Icingadb/ProvidedHook/ApplicationState.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook;
 

--- a/library/Icingadb/ProvidedHook/IcingaHealth.php
+++ b/library/Icingadb/ProvidedHook/IcingaHealth.php
@@ -1,6 +1,6 @@
 <?php
 
-// Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2
+// Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+
 
 namespace Icinga\Module\Icingadb\ProvidedHook;
 

--- a/library/Icingadb/ProvidedHook/Notifications/V1/Source.php
+++ b/library/Icingadb/ProvidedHook/Notifications/V1/Source.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\Notifications\V1;
 

--- a/library/Icingadb/ProvidedHook/RedisHealth.php
+++ b/library/Icingadb/ProvidedHook/RedisHealth.php
@@ -1,6 +1,6 @@
 <?php
 
-// Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2
+// Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+
 
 namespace Icinga\Module\Icingadb\ProvidedHook;
 

--- a/library/Icingadb/ProvidedHook/Reporting/HostSlaReport.php
+++ b/library/Icingadb/ProvidedHook/Reporting/HostSlaReport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\Reporting;
 

--- a/library/Icingadb/ProvidedHook/Reporting/ServiceSlaReport.php
+++ b/library/Icingadb/ProvidedHook/Reporting/ServiceSlaReport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\Reporting;
 

--- a/library/Icingadb/ProvidedHook/Reporting/SlaReport.php
+++ b/library/Icingadb/ProvidedHook/Reporting/SlaReport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\Reporting;
 

--- a/library/Icingadb/ProvidedHook/Reporting/TotalHostSlaReport.php
+++ b/library/Icingadb/ProvidedHook/Reporting/TotalHostSlaReport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\Reporting;
 

--- a/library/Icingadb/ProvidedHook/Reporting/TotalServiceSlaReport.php
+++ b/library/Icingadb/ProvidedHook/Reporting/TotalServiceSlaReport.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\Reporting;
 

--- a/library/Icingadb/ProvidedHook/X509/Sni.php
+++ b/library/Icingadb/ProvidedHook/X509/Sni.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\ProvidedHook\X509;
 

--- a/library/Icingadb/Redis/VolatileStateResults.php
+++ b/library/Icingadb/Redis/VolatileStateResults.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Redis;
 

--- a/library/Icingadb/Setup/ApiTransportPage.php
+++ b/library/Icingadb/Setup/ApiTransportPage.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/ApiTransportStep.php
+++ b/library/Icingadb/Setup/ApiTransportStep.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/DbResourcePage.php
+++ b/library/Icingadb/Setup/DbResourcePage.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/DbResourceStep.php
+++ b/library/Icingadb/Setup/DbResourceStep.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/IcingaDbWizard.php
+++ b/library/Icingadb/Setup/IcingaDbWizard.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/RedisPage.php
+++ b/library/Icingadb/Setup/RedisPage.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/RedisStep.php
+++ b/library/Icingadb/Setup/RedisStep.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Setup/WelcomePage.php
+++ b/library/Icingadb/Setup/WelcomePage.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Setup;
 

--- a/library/Icingadb/Util/FeatureStatus.php
+++ b/library/Icingadb/Util/FeatureStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/Util/ObjectSuggestionsCursor.php
+++ b/library/Icingadb/Util/ObjectSuggestionsCursor.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/Util/PerfData.php
+++ b/library/Icingadb/Util/PerfData.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/Util/PerfDataFormat.php
+++ b/library/Icingadb/Util/PerfDataFormat.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/Util/PerfDataSet.php
+++ b/library/Icingadb/Util/PerfDataSet.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/Util/PluginOutput.php
+++ b/library/Icingadb/Util/PluginOutput.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/Util/ThresholdRange.php
+++ b/library/Icingadb/Util/ThresholdRange.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Util;
 

--- a/library/Icingadb/View/BaseHostAndServiceRenderer.php
+++ b/library/Icingadb/View/BaseHostAndServiceRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/CommentRenderer.php
+++ b/library/Icingadb/View/CommentRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/DowntimeRenderer.php
+++ b/library/Icingadb/View/DowntimeRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/EventRenderer.php
+++ b/library/Icingadb/View/EventRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/HostRenderer.php
+++ b/library/Icingadb/View/HostRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/HostgroupGridRenderer.php
+++ b/library/Icingadb/View/HostgroupGridRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/HostgroupRenderer.php
+++ b/library/Icingadb/View/HostgroupRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/NotificationRenderer.php
+++ b/library/Icingadb/View/NotificationRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/RedundancyGroupRenderer.php
+++ b/library/Icingadb/View/RedundancyGroupRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/ServiceRenderer.php
+++ b/library/Icingadb/View/ServiceRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/ServicegroupGridRenderer.php
+++ b/library/Icingadb/View/ServicegroupGridRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/ServicegroupRenderer.php
+++ b/library/Icingadb/View/ServicegroupRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/UserRenderer.php
+++ b/library/Icingadb/View/UserRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/View/UsergroupRenderer.php
+++ b/library/Icingadb/View/UsergroupRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\View;
 

--- a/library/Icingadb/Web/Control/GridViewModeSwitcher.php
+++ b/library/Icingadb/Web/Control/GridViewModeSwitcher.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Control;
 

--- a/library/Icingadb/Web/Control/ProblemToggle.php
+++ b/library/Icingadb/Web/Control/ProblemToggle.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Control;
 

--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Control\SearchBar;
 

--- a/library/Icingadb/Web/Control/ViewModeSwitcher.php
+++ b/library/Icingadb/Web/Control/ViewModeSwitcher.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Control;
 

--- a/library/Icingadb/Web/Controller.php
+++ b/library/Icingadb/Web/Controller.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web;
 

--- a/library/Icingadb/Web/Navigation/Action.php
+++ b/library/Icingadb/Web/Navigation/Action.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation;
 

--- a/library/Icingadb/Web/Navigation/IcingadbHostAction.php
+++ b/library/Icingadb/Web/Navigation/IcingadbHostAction.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation;
 

--- a/library/Icingadb/Web/Navigation/IcingadbServiceAction.php
+++ b/library/Icingadb/Web/Navigation/IcingadbServiceAction.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation;
 

--- a/library/Icingadb/Web/Navigation/Renderer/HostProblemsBadge.php
+++ b/library/Icingadb/Web/Navigation/Renderer/HostProblemsBadge.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation\Renderer;
 

--- a/library/Icingadb/Web/Navigation/Renderer/ProblemsBadge.php
+++ b/library/Icingadb/Web/Navigation/Renderer/ProblemsBadge.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation\Renderer;
 

--- a/library/Icingadb/Web/Navigation/Renderer/ServiceProblemsBadge.php
+++ b/library/Icingadb/Web/Navigation/Renderer/ServiceProblemsBadge.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation\Renderer;
 

--- a/library/Icingadb/Web/Navigation/Renderer/TotalProblemsBadge.php
+++ b/library/Icingadb/Web/Navigation/Renderer/TotalProblemsBadge.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Web\Navigation\Renderer;
 

--- a/library/Icingadb/Widget/CheckAttempt.php
+++ b/library/Icingadb/Widget/CheckAttempt.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/DependencyNodeStateBadges.php
+++ b/library/Icingadb/Widget/DependencyNodeStateBadges.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/DependencyNodeStatistics.php
+++ b/library/Icingadb/Widget/DependencyNodeStatistics.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/Detail/CheckStatistics.php
+++ b/library/Icingadb/Widget/Detail/CheckStatistics.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/CommentDetail.php
+++ b/library/Icingadb/Widget/Detail/CommentDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/CustomVarTable.php
+++ b/library/Icingadb/Widget/Detail/CustomVarTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/DowntimeCard.php
+++ b/library/Icingadb/Widget/Detail/DowntimeCard.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/DowntimeDetail.php
+++ b/library/Icingadb/Widget/Detail/DowntimeDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/EventDetail.php
+++ b/library/Icingadb/Widget/Detail/EventDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/HostDetail.php
+++ b/library/Icingadb/Widget/Detail/HostDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/HostInspectionDetail.php
+++ b/library/Icingadb/Widget/Detail/HostInspectionDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/HostMetaInfo.php
+++ b/library/Icingadb/Widget/Detail/HostMetaInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/HostStatistics.php
+++ b/library/Icingadb/Widget/Detail/HostStatistics.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/MultiselectQuickActions.php
+++ b/library/Icingadb/Widget/Detail/MultiselectQuickActions.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ObjectDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ObjectHeader.php
+++ b/library/Icingadb/Widget/Detail/ObjectHeader.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ObjectStatistics.php
+++ b/library/Icingadb/Widget/Detail/ObjectStatistics.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ObjectsDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectsDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/PerfDataTable.php
+++ b/library/Icingadb/Widget/Detail/PerfDataTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/QuickActions.php
+++ b/library/Icingadb/Widget/Detail/QuickActions.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/RedundancyGroupDetail.php
+++ b/library/Icingadb/Widget/Detail/RedundancyGroupDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ServiceDetail.php
+++ b/library/Icingadb/Widget/Detail/ServiceDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ServiceInspectionDetail.php
+++ b/library/Icingadb/Widget/Detail/ServiceInspectionDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ServiceMetaInfo.php
+++ b/library/Icingadb/Widget/Detail/ServiceMetaInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/ServiceStatistics.php
+++ b/library/Icingadb/Widget/Detail/ServiceStatistics.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/UserDetail.php
+++ b/library/Icingadb/Widget/Detail/UserDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Detail/UsergroupDetail.php
+++ b/library/Icingadb/Widget/Detail/UsergroupDetail.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 

--- a/library/Icingadb/Widget/Health.php
+++ b/library/Icingadb/Widget/Health.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/HostStateBadges.php
+++ b/library/Icingadb/Widget/HostStateBadges.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/HostStatusBar.php
+++ b/library/Icingadb/Widget/HostStatusBar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/HostSummaryDonut.php
+++ b/library/Icingadb/Widget/HostSummaryDonut.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/IconImage.php
+++ b/library/Icingadb/Widget/IconImage.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/ItemList/CommandTransportList.php
+++ b/library/Icingadb/Widget/ItemList/CommandTransportList.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 

--- a/library/Icingadb/Widget/ItemList/CommandTransportListItem.php
+++ b/library/Icingadb/Widget/ItemList/CommandTransportListItem.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 

--- a/library/Icingadb/Widget/ItemList/LoadMoreObjectList.php
+++ b/library/Icingadb/Widget/ItemList/LoadMoreObjectList.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 

--- a/library/Icingadb/Widget/ItemList/ObjectList.php
+++ b/library/Icingadb/Widget/ItemList/ObjectList.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 

--- a/library/Icingadb/Widget/ItemList/PageSeparatorItem.php
+++ b/library/Icingadb/Widget/ItemList/PageSeparatorItem.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 

--- a/library/Icingadb/Widget/ItemList/TicketLinkObjectList.php
+++ b/library/Icingadb/Widget/ItemList/TicketLinkObjectList.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemList;
 

--- a/library/Icingadb/Widget/ItemTable/BaseStateRowItem.php
+++ b/library/Icingadb/Widget/ItemTable/BaseStateRowItem.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/HostItemTable.php
+++ b/library/Icingadb/Widget/ItemTable/HostItemTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/HostRowItem.php
+++ b/library/Icingadb/Widget/ItemTable/HostRowItem.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/ObjectGrid.php
+++ b/library/Icingadb/Widget/ItemTable/ObjectGrid.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/ObjectTable.php
+++ b/library/Icingadb/Widget/ItemTable/ObjectTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/ServiceItemTable.php
+++ b/library/Icingadb/Widget/ItemTable/ServiceItemTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/ServiceRowItem.php
+++ b/library/Icingadb/Widget/ItemTable/ServiceRowItem.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/StateItemTable.php
+++ b/library/Icingadb/Widget/ItemTable/StateItemTable.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/ItemTable/StateRowItem.php
+++ b/library/Icingadb/Widget/ItemTable/StateRowItem.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget\ItemTable;
 

--- a/library/Icingadb/Widget/MarkdownLine.php
+++ b/library/Icingadb/Widget/MarkdownLine.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/MarkdownText.php
+++ b/library/Icingadb/Widget/MarkdownText.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/Notice.php
+++ b/library/Icingadb/Widget/Notice.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/PluginOutputContainer.php
+++ b/library/Icingadb/Widget/PluginOutputContainer.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/ServiceStateBadges.php
+++ b/library/Icingadb/Widget/ServiceStateBadges.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/ServiceStatusBar.php
+++ b/library/Icingadb/Widget/ServiceStatusBar.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/ServiceSummaryDonut.php
+++ b/library/Icingadb/Widget/ServiceSummaryDonut.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/ShowMore.php
+++ b/library/Icingadb/Widget/ShowMore.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/StateBadge.php
+++ b/library/Icingadb/Widget/StateBadge.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/StateChange.php
+++ b/library/Icingadb/Widget/StateChange.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/library/Icingadb/Widget/TagList.php
+++ b/library/Icingadb/Widget/TagList.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Module\Icingadb\Widget;
 

--- a/public/css/common.less
+++ b/public/css/common.less
@@ -1,4 +1,4 @@
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 @exports: {
   @iplWebAssets: "../lib/icinga/icinga-php-library";

--- a/public/css/mixins.less
+++ b/public/css/mixins.less
@@ -1,4 +1,4 @@
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 .monospace() {
   font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;

--- a/public/css/widget/performance-data-table.less
+++ b/public/css/widget/performance-data-table.less
@@ -1,4 +1,4 @@
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 .performance-data-table {
   width: 100%;

--- a/public/js/action-list.js
+++ b/public/js/action-list.js
@@ -1,4 +1,4 @@
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 ;(function (Icinga) {
 

--- a/run.php
+++ b/run.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2+ */
 
 /** @var $this \Icinga\Application\Modules\Module */
 

--- a/test/php/Lib/PerfdataSetWithPublicData.php
+++ b/test/php/Lib/PerfdataSetWithPublicData.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Module\Icingadb\Lib;
 

--- a/test/php/application/clicommands/MigrateCommandTest.php
+++ b/test/php/application/clicommands/MigrateCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Module\Icingadb\Clicommands;
 

--- a/test/php/library/Icingadb/Common/MacrosTest.php
+++ b/test/php/library/Icingadb/Common/MacrosTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Modules\Icingadb\Common;
 

--- a/test/php/library/Icingadb/Common/StateBadgesTest.php
+++ b/test/php/library/Icingadb/Common/StateBadgesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Modules\Icingadb\Common;
 

--- a/test/php/library/Icingadb/Model/Behavior/FlattenedObjectVarsTest.php
+++ b/test/php/library/Icingadb/Model/Behavior/FlattenedObjectVarsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Modules\Icingadb\Model\Behavior;
 

--- a/test/php/library/Icingadb/Model/CustomvarFlatTest.php
+++ b/test/php/library/Icingadb/Model/CustomvarFlatTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Modules\Icingadb\Model;
 

--- a/test/php/library/Icingadb/ProvidedHook/IcingaHealthTest.php
+++ b/test/php/library/Icingadb/ProvidedHook/IcingaHealthTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Modules\Icingadb\ProvidedHook;
 

--- a/test/php/library/Icingadb/Util/PerfdataSetTest.php
+++ b/test/php/library/Icingadb/Util/PerfdataSetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Module\Icingadb\Util;
 

--- a/test/php/library/Icingadb/Util/PerfdataTest.php
+++ b/test/php/library/Icingadb/Util/PerfdataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Module\Icingadb\Util;
 

--- a/test/php/library/Icingadb/Util/PluginOutputTest.php
+++ b/test/php/library/Icingadb/Util/PluginOutputTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Module\Icingadb\Util;
 

--- a/test/php/library/Icingadb/Util/ThresholdRangeTest.php
+++ b/test/php/library/Icingadb/Util/ThresholdRangeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2+ */
 
 namespace Tests\Icinga\Module\Icingadb\Util;
 


### PR DESCRIPTION
This was easy because only README.md and doc/01-About.md were redacted manually, everything else via: `git ls-files -z |xargs -0 perl -pi -e 's/Icinga GmbH \| GPLv2/Icinga GmbH | GPLv2+/'`

This is legal because we have only merged PRs with label:cla/signed or made by Icinga staff: https://github.com/Icinga/icingadb-web/pulls?page=1&q=is%3Apr+is%3Aclosed+-label%3Acla%2Fsigned+-author%3Anilmerg

This has no risk for us in people distributing their own version under GPLv3 only. After all, we won't take their patches anyway, unless they sign our CLA.

This is the cleanest solution for having e.g. these in one address space:

* Icinga Web, GPLv2+
* K8s Web, AGPLv3
* Thirdparty, some LGPLv3 and Apache-2.0 https://github.com/Icinga/icinga-php-thirdparty/issues/65

Apropos, K8s Web is even v3-licensed on purpose, to have a stronger protection against cloud ops.