### PR TITLE
VolatileStateResults: Fetch individual redis results for the actual current item

### DIFF
--- a/library/Icingadb/Redis/VolatileStateResults.php
+++ b/library/Icingadb/Redis/VolatileStateResults.php
@@ -84,20 +84,15 @@ class VolatileStateResults extends ResultSet
         }
 
         $result = parent::current();
+        if ($this->isCacheDisabled && ! $this->redisUnavailable) {
+            $this->applyRedisUpdates([$result]);
+        }
+
         if (! $this->includeModelID) {
             unset($result['id']);
         }
 
         return $result;
-    }
-
-    public function next(): void
-    {
-        parent::next();
-
-        if (! $this->redisUnavailable && $this->isCacheDisabled && $this->valid()) {
-            $this->applyRedisUpdates([parent::current()]);
-        }
     }
 
     public function key(): int


### PR DESCRIPTION
Previously, only the second and other subsequent item was updated with redis results. Not sure why this wasn't discovered until recently, as the issue was already part of the initial fix meant for a very similar issue, affecting *all* items. Hell, maybe because my initial analysis this time also led me into the wrong direction, so when reviewing this, proper testing and result verification is key!

fixes #1318