### PR TITLE
change table layout from fixed to auto

### DIFF
--- a/public/css/list/state-item-table.less
+++ b/public/css/list/state-item-table.less
@@ -67,7 +67,7 @@
 // Layout
 
 table.state-item-table {
-  table-layout: fixed;
+  table-layout: auto;
 }
 
 .state-item-table {


### PR DESCRIPTION
this removes alot of empty space when specifying columns in the url for example:
/icingaweb2/icingadb/services?columns=host.vars.sla,host.name,service.name,service.state.last_state_change,service.state.output

From this:
<img width="1706" height="402" alt="image" src="https://github.com/user-attachments/assets/1d0eb7d3-bf18-4068-966d-3524cfba5706" />

To this: 
<img width="1700" height="395" alt="image" src="https://github.com/user-attachments/assets/73a200ee-54b6-4dbf-893b-d2d4c26a71c0" />


Dont know if this messes with other views or something, but i've been using it for about a week and have not noticed any weird behaviour. 