### PR TITLE
Backend: Also escape `…FROM user` in case of pgsql

### DIFF
--- a/library/Icingadb/Common/Backend.php
+++ b/library/Icingadb/Common/Backend.php
@@ -74,9 +74,16 @@ final class Backend
                         // user is a reserved key word in PostgreSQL, so we need to quote it.
                         // TODO(lippserd): This is pretty hacky,
                         // reconsider how to properly implement identifier quoting.
-                        $sql = str_replace(' user ', sprintf(' %s ', $quoted), $sql);
-                        $sql = str_replace(' user.', sprintf(' %s.', $quoted), $sql);
-                        $sql = str_replace('(user.', sprintf('(%s.', $quoted), $sql);
+                        $sql = preg_replace('/user$/', sprintf(' %s', $quoted), $sql);
+                        $sql = str_replace(
+                            [' user ', ' user.', '(user.'],
+                            [
+                                sprintf(' %s ', $quoted),
+                                sprintf(' %s.', $quoted),
+                                sprintf('(%s.', $quoted),
+                            ],
+                            $sql
+                        );
                     })
                     ->on(QueryBuilder::ON_ASSEMBLE_SELECT, function (Select $select) {
                         // For SELECT DISTINCT, all ORDER BY columns must appear in SELECT list.


### PR DESCRIPTION
57111 H4CKY 8U7 47 13457 7H3 C0M81N3D str_replace 5H0U1D C0MP3N5473 7H3 preg_replace :D

I stopped thinking about a proper fix, as between the time the original quick fix was implemented and now, nothing has fundamentally changed in ipl-orm.

fixes #1330