### PR TITLE
Ensure forward compatibility with `ipl-orm` by adding return types

### DIFF
--- a/library/Icingadb/Model/Behavior/Bitmask.php
+++ b/library/Icingadb/Model/Behavior/Bitmask.php
@@ -54,17 +54,17 @@ class Bitmask extends PropertyBehavior implements RewriteFilterBehavior
         return $bits;
     }
 
-    public function rewriteCondition(Condition $condition, $relation = null)
+    public function rewriteCondition(Condition $condition, $relation = null): null
     {
         $column = $condition->metaData()->get('columnName');
         if ($column === null || ! isset($this->properties[$column])) {
-            return;
+            return null;
         }
 
         $values = $condition->getValue();
         if (! is_array($values)) {
             if (is_int($values) || ctype_digit($values)) {
-                return;
+                return null;
             }
 
             $values = [$values];
@@ -80,5 +80,7 @@ class Bitmask extends PropertyBehavior implements RewriteFilterBehavior
         }
 
         $condition->setColumn(sprintf('%s & %s', $condition->getColumn(), $bits));
+
+        return null;
     }
 }

--- a/library/Icingadb/Model/Behavior/FlattenedObjectVars.php
+++ b/library/Icingadb/Model/Behavior/FlattenedObjectVars.php
@@ -27,14 +27,14 @@ class FlattenedObjectVars implements RewriteColumnBehavior, QueryAwareBehavior
     /** @var Query */
     protected $query;
 
-    public function setQuery(Query $query)
+    public function setQuery(Query $query): static
     {
         $this->query = $query;
 
         return $this;
     }
 
-    public function rewriteCondition(Filter\Condition $condition, $relation = null)
+    public function rewriteCondition(Filter\Condition $condition, $relation = null): ?Filter\Condition
     {
         $column = $condition->metaData()->get('columnName');
         if ($column !== null) {
@@ -72,9 +72,11 @@ class FlattenedObjectVars implements RewriteColumnBehavior, QueryAwareBehavior
 
             return $condition;
         }
+
+        return null;
     }
 
-    public function rewriteColumn($column, $relation = null)
+    public function rewriteColumn($column, ?string $relation = null): AliasedExpression
     {
         $subQuery = $this->query->createSubQuery(new CustomvarFlat(), $relation)
             ->limit(1)

--- a/library/Icingadb/Model/Behavior/HasProblematicParent.php
+++ b/library/Icingadb/Model/Behavior/HasProblematicParent.php
@@ -23,7 +23,7 @@ class HasProblematicParent implements RewriteColumnBehavior, QueryAwareBehavior
     /** @var Query */
     protected $query;
 
-    public function setQuery(Query $query): self
+    public function setQuery(Query $query): static
     {
         $this->query = $query;
 
@@ -84,12 +84,14 @@ class HasProblematicParent implements RewriteColumnBehavior, QueryAwareBehavior
     {
     }
 
-    public function rewriteCondition(Filter\Condition $condition, $relation = null)
+    public function rewriteCondition(Filter\Condition $condition, $relation = null): null
     {
         $column = substr($condition->getColumn(), strlen($relation ?? ''));
 
         if ($this->isSelectableColumn($column)) {
             throw new InvalidColumnException($column, $this->query->getModel());
         }
+
+        return null;
     }
 }

--- a/library/Icingadb/Model/Behavior/ReRoute.php
+++ b/library/Icingadb/Model/Behavior/ReRoute.php
@@ -30,11 +30,11 @@ class ReRoute implements RewriteFilterBehavior, RewritePathBehavior
         return $this->routes;
     }
 
-    public function rewriteCondition(Filter\Condition $condition, $relation = null)
+    public function rewriteCondition(Filter\Condition $condition, $relation = null): ?Filter\Rule
     {
         $remainingPath = $condition->metaData()->get('columnName', '');
         if (strpos($remainingPath, '.') === false) {
-            return;
+            return null;
         }
 
         if (($path = $this->rewritePath($remainingPath, $relation)) !== null) {
@@ -64,6 +64,8 @@ class ReRoute implements RewriteFilterBehavior, RewritePathBehavior
 
             return $filter;
         }
+
+        return null;
     }
 
     public function rewritePath(string $path, ?string $relation = null): ?string

--- a/library/Icingadb/Model/CustomvarFlat.php
+++ b/library/Icingadb/Model/CustomvarFlat.php
@@ -55,7 +55,7 @@ class CustomvarFlat extends Model
             'flatname_checksum'
         ]));
         $behaviors->add(new class implements RewriteFilterBehavior {
-            public function rewriteCondition(Condition $condition, $relation = null)
+            public function rewriteCondition(Condition $condition, $relation = null): ?Filter\Chain
             {
                 if ($condition->metaData()->has('requiresTransformation')) {
                     /** @var string $columnName */
@@ -66,6 +66,8 @@ class CustomvarFlat extends Model
 
                     return Filter::all($nameFilter, $valueFilter);
                 }
+
+                return null;
             }
         });
     }

--- a/library/Icingadb/Model/Hostgroupsummary.php
+++ b/library/Icingadb/Model/Hostgroupsummary.php
@@ -11,6 +11,7 @@ use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Orm\UnionModel;
+use ipl\Orm\UnionQuery;
 use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Connection;
 use ipl\Sql\Expression;
@@ -39,7 +40,7 @@ use ipl\Sql\Select;
  */
 class Hostgroupsummary extends UnionModel
 {
-    public static function on(Connection $db)
+    public static function on(Connection $db): UnionQuery
     {
         $q = parent::on($db);
 
@@ -157,7 +158,7 @@ class Hostgroupsummary extends UnionModel
         return 'display_name';
     }
 
-    public function getUnions()
+    public function getUnions(): array
     {
         $unions = [
             [

--- a/library/Icingadb/Model/ServicegroupSummary.php
+++ b/library/Icingadb/Model/ServicegroupSummary.php
@@ -11,6 +11,7 @@ use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Orm\UnionModel;
+use ipl\Orm\UnionQuery;
 use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Connection;
 use ipl\Sql\Expression;
@@ -34,7 +35,7 @@ use ipl\Sql\Select;
  */
 class ServicegroupSummary extends UnionModel
 {
-    public static function on(Connection $db)
+    public static function on(Connection $db): UnionQuery
     {
         $q = parent::on($db);
 
@@ -135,7 +136,7 @@ class ServicegroupSummary extends UnionModel
         return 'display_name';
     }
 
-    public function getUnions()
+    public function getUnions(): array
     {
         $unions = [
             [

--- a/library/Icingadb/Model/UnreachableParent/ResultSet.php
+++ b/library/Icingadb/Model/UnreachableParent/ResultSet.php
@@ -5,12 +5,13 @@
 
 namespace Icinga\Module\Icingadb\Model\UnreachableParent;
 
+use Generator;
 use Icinga\Module\Icingadb\Redis\VolatileStateResults;
 use Traversable;
 
 class ResultSet extends VolatileStateResults
 {
-    protected function yieldTraversable(Traversable $traversable)
+    protected function yieldTraversable(Traversable $traversable): Generator
     {
         $knownIds = [];
         foreach ($traversable as $value) {

--- a/library/Icingadb/Redis/VolatileStateResults.php
+++ b/library/Icingadb/Redis/VolatileStateResults.php
@@ -43,7 +43,7 @@ class VolatileStateResults extends ResultSet
     /** @var bool Whether the model's ID should be contained in the results */
     protected bool $includeModelID = true;
 
-    public static function fromQuery(Query $query)
+    public static function fromQuery(Query $query): static
     {
         $self = parent::fromQuery($query);
         $self->resolver = $query->getResolver();
@@ -77,8 +77,7 @@ class VolatileStateResults extends ResultSet
         return $this->redisUnavailable;
     }
 
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         if (! $this->redisUnavailable && ! $this->updatesApplied && ! $this->isCacheDisabled) {
             $this->rewind();


### PR DESCRIPTION
Add explicit return types to `ipl-orm`-derived methods to prepare for strict
typing. These additions are safe, as they only annotate existing methods that
previously lacked return type declarations.

refs Icinga/ipl-orm#158