### PR TITLE
Fix leading comma in JSON export

### DIFF
--- a/library/Icingadb/Data/JsonResultSetUtils.php
+++ b/library/Icingadb/Data/JsonResultSetUtils.php
@@ -85,13 +85,16 @@ trait JsonResultSetUtils
             $offset = 0;
         }
 
+        $first = true;
         echo '[';
 
         do {
             $query->offset($offset);
             $result = $query->execute()->disableCache();
-            foreach ($result as $i => $object) {
-                if ($i > 0 || $offset !== 0) {
+            foreach ($result as $object) {
+                if ($first) {
+                    $first = false;
+                } else {
                     echo ",\n";
                 }
 


### PR DESCRIPTION
When exporting JSON with a limit and a page > 1 set, a leading comma is added before the first item because (`$offset !== 0`) evaluates to true, resulting in invalid JSON.

Replace the offset-based condition with a `$first` flag to track whether any item has been written yet.

fixes #1343 