### PR TITLE
Fix incorrect start times in the timelines of fixed downtimes

### DIFF
--- a/library/Icingadb/Widget/Detail/DowntimeCard.php
+++ b/library/Icingadb/Widget/Detail/DowntimeCard.php
@@ -217,7 +217,12 @@ class DowntimeCard extends BaseHtmlElement
                     Html::tag(
                         'div',
                         ['class' => 'bubble upwards'],
-                        new VerticalKeyValue(t('Start'), new TimeAgo($this->start))
+                        new VerticalKeyValue(
+                            t('Start'),
+                            time() >= $this->start
+                                ? new TimeAgo($this->start)
+                                : new TimeUntil($this->start)
+                        )
                     )
                 ),
                 Html::tag(


### PR DESCRIPTION
Downtimecards for fixed downtimes currently always use `TimeAgo` to display the start time in the timeline, which is incorrect if the start is in the future, for such cases `TimeUntil` should be used instead.

I tested the change with the current main of ipl-web and with https://github.com/Icinga/ipl-web/pull/350 and it's dependencies, both worked fine.

resolves: #1353 