### PR TITLE
Fix `LoadMore` in the service history

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -141,8 +141,9 @@ class HostController extends Controller
 
         $before = $this->params->shift('before', time());
         $previousTimestamp = $this->params->shift('last-entry');
-        $url = Url::fromRequest()->setParams(clone $this->params);
-        $url->setParam('name', $this->host->name);
+        $url = Url::fromRequest()->setParams(
+            (clone $this->params)->add('name', $this->host->name)
+        );
 
         $timestampControl = $this->createTimestampControl();
         $limitControl = $this->createLimitControl();

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -291,8 +291,10 @@ class ServiceController extends Controller
 
         $before = $this->params->shift('before', time());
         $previousTimestamp = $this->params->shift('last-entry');
-        $url = Url::fromRequest()->setParams(clone $this->params);
-        $url->setParams(['name' => $this->service->name, 'host.name' => $this->service->host->name]);
+        $url = Url::fromRequest()->setParams(
+            (clone $this->params)
+                ->addValues(['name' => $this->service->name, 'host.name' => $this->service->host->name])
+        );
 
         $timestampControl = $this->createTimestampControl();
         $limitControl = $this->createLimitControl();


### PR DESCRIPTION
`ServiceController::historyAction` previously used `Url::setParams` to set the parameters `name` and `host.name` in the URL for the load-more link.
This removed the `sort` parameter from the URL, so load-more always added elements in ascending order.

Using `UrlParams::addValues` does not affect the `sort` parameter and load-more in descending order works fine.

For consistency `HostController::historyAction` is also adjusted.

fix https://github.com/Icinga/icingadb-web/issues/1363

