### PR TITLE
css: Don't export `@iplWebAssets` anymore

### DIFF
--- a/public/css/common.less
+++ b/public/css/common.less
@@ -1,10 +1,6 @@
 // SPDX-FileCopyrightText: 2019 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-@exports: {
-  @iplWebAssets: "../lib/icinga/icinga-php-library";
-};
-
 & > .content.full-height {
   padding-top: 0;
   padding-bottom: 0;


### PR DESCRIPTION
This variable is available since Icinga Web v2.9.0. (https://github.com/Icinga/icingaweb2/pull/4381)
The `@exports` feature is not ported to ipl-web with https://github.com/Icinga/ipl-web/pull/365.