### PR TITLE
Fix tactical overview export

### DIFF
--- a/application/controllers/TacticalController.php
+++ b/application/controllers/TacticalController.php
@@ -6,15 +6,13 @@
 namespace Icinga\Module\Icingadb\Controllers;
 
 use GuzzleHttp\Psr7\ServerRequest;
-use Icinga\Module\Icingadb\Model\HoststateSummary;
 use Icinga\Module\Icingadb\Model\ServicestateSummary;
+use Icinga\Module\Icingadb\Model\TacticalStateSummary;
 use Icinga\Module\Icingadb\Web\Control\SearchBar\ObjectSuggestions;
 use Icinga\Module\Icingadb\Web\Controller;
 use Icinga\Module\Icingadb\Widget\HostSummaryDonut;
 use Icinga\Module\Icingadb\Widget\ServiceSummaryDonut;
 use Icinga\Module\Icingadb\Web\Control\ViewModeSwitcher;
-use ipl\Orm\Query;
-use ipl\Stdlib\Filter;
 use ipl\Web\Control\LimitControl;
 use ipl\Web\Control\SortControl;
 
@@ -26,17 +24,16 @@ class TacticalController extends Controller
 
         $db = $this->getDb();
 
-        $hoststateSummary = HoststateSummary::on($db);
-        $servicestateSummary = ServicestateSummary::on($db);
+        $tacticalSummary = TacticalStateSummary::on($db);
 
-        $this->handleSearchRequest($servicestateSummary, [
+        $this->handleSearchRequest($tacticalSummary, [
             'host.name_ci',
             'host.display_name',
             'host.address',
             'host.address6'
         ]);
 
-        $searchBar = $this->createSearchBar($servicestateSummary);
+        $searchBar = $this->createSearchBar($tacticalSummary);
         if ($searchBar->hasBeenSent() && ! $searchBar->isValid()) {
             if ($searchBar->hasBeenSubmitted()) {
                 $filter = $this->getFilter();
@@ -49,22 +46,26 @@ class TacticalController extends Controller
             $filter = $searchBar->getFilter();
         }
 
-        $this->filter($hoststateSummary, $filter);
-        $this->filter($servicestateSummary, $filter);
+        $this->filter($tacticalSummary, $filter);
 
-        yield $this->export($hoststateSummary, $servicestateSummary);
+        yield $this->export($tacticalSummary);
 
         $this->addControl($searchBar);
 
-        $this->addContent(
-            (new HostSummaryDonut($hoststateSummary->first()))
-                ->setBaseFilter($filter)
-        );
-
-        $this->addContent(
-            (new ServiceSummaryDonut($servicestateSummary->first()))
-                ->setBaseFilter($filter)
-        );
+        foreach ($tacticalSummary as $row) {
+            // The query is a union and always yields host state results first
+            if ($row->type === "host_state") {
+                $this->addContent(
+                    (new HostSummaryDonut($row))
+                        ->setBaseFilter($filter)
+                );
+            } elseif ($row->type === "service_state") {
+                $this->addContent(
+                    (new ServiceSummaryDonut($row))
+                        ->setBaseFilter($filter)
+                );
+            }
+        }
 
         if (! $searchBar->hasBeenSubmitted() && $searchBar->hasBeenSent()) {
             $this->sendMultipartUpdate();

--- a/library/Icingadb/Model/TacticalStateSummary.php
+++ b/library/Icingadb/Model/TacticalStateSummary.php
@@ -1,0 +1,140 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Icingadb\Model;
+
+use Icinga\Module\Icingadb\Common\Auth;
+use ipl\Orm\Query;
+use ipl\Orm\Relations;
+use ipl\Orm\UnionModel;
+use ipl\Sql\Connection;
+use ipl\Sql\Expression;
+
+/**
+ * @property string $type
+ * @property ?int $hosts_acknowledged
+ * @property ?int $hosts_active_checks_enabled
+ * @property ?int $hosts_passive_checks_enabled
+ * @property ?int $hosts_down_handled
+ * @property ?int $hosts_down_unhandled
+ * @property ?int $hosts_event_handler_enabled
+ * @property ?int $hosts_flapping_enabled
+ * @property ?int $hosts_notifications_enabled
+ * @property ?int $hosts_pending
+ * @property ?int $hosts_problems_unacknowledged
+ * @property ?int $hosts_total
+ * @property ?int $hosts_up
+ * @property ?int $services_acknowledged
+ * @property ?int $services_active_checks_enabled
+ * @property ?int $services_passive_checks_enabled
+ * @property ?int $services_critical_handled
+ * @property ?int $services_critical_unhandled
+ * @property ?int $services_event_handler_enabled
+ * @property ?int $services_flapping_enabled
+ * @property ?int $services_notifications_enabled
+ * @property ?int $services_ok
+ * @property ?int $services_pending
+ * @property ?int $services_problems_unacknowledged
+ * @property ?int $services_total
+ * @property ?int $services_unknown_handled
+ * @property ?int $services_unknown_unhandled
+ * @property ?int $services_warning_handled
+ * @property ?int $services_warning_unhandled
+ */
+class TacticalStateSummary extends UnionModel
+{
+    public static function on(Connection $db)
+    {
+        $q = parent::on($db);
+
+        $q->on(
+            Query::ON_SELECT_ASSEMBLED,
+            function () use ($q) {
+                $auth = new class () {
+                    use Auth;
+                };
+
+                $auth->assertColumnRestrictions($q->getFilter());
+            }
+        );
+
+        return $q;
+    }
+
+    public function getTableName(): string
+    {
+        return 'tactical_summary';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'type';
+    }
+
+    public function getColumns(): array
+    {
+        return array_merge(
+            array_keys((new HoststateSummary())->getSummaryColumns()),
+            array_keys((new ServicestateSummary())->getSummaryColumns())
+        );
+    }
+
+    public function getColumnDefinitions(): array
+    {
+        // This is because there is still no better way
+        return (new ServicestateSummary())->getColumnDefinitions();
+    }
+
+    public function getDefaultSort(): array
+    {
+        return [];
+    }
+
+    public function getSearchColumns(): array
+    {
+        return ['service.name_ci', 'host.name_ci'];
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        // This is because there is still no better way
+        (new ServicestateSummary())->createRelations($relations);
+        // And because of that a fake service relation is needed
+        $relations->belongsTo('service', Service::class);
+    }
+
+    public function getUnions(): array
+    {
+        $hostStateSummaryColumns = array_keys((new HoststateSummary())->getSummaryColumns());
+        $serviceStateSummaryColumns = array_keys((new ServicestateSummary())->getSummaryColumns());
+
+        return [
+            [
+                HoststateSummary::class,
+                [],
+                array_merge(
+                    ['type' => new Expression("'host_state'")],
+                    $hostStateSummaryColumns,
+                    array_combine(
+                        $serviceStateSummaryColumns,
+                        array_fill(0, count($serviceStateSummaryColumns), new Expression('NULL'))
+                    )
+                )
+            ],
+            [
+                ServicestateSummary::class,
+                [],
+                array_merge(
+                    ['type' => new Expression("'service_state'")],
+                    array_combine(
+                        $hostStateSummaryColumns,
+                        array_fill(0, count($hostStateSummaryColumns), new Expression('NULL'))
+                    ),
+                    $serviceStateSummaryColumns
+                )
+            ]
+        ];
+    }
+}

--- a/library/Icingadb/Widget/HostSummaryDonut.php
+++ b/library/Icingadb/Widget/HostSummaryDonut.php
@@ -8,6 +8,7 @@ namespace Icinga\Module\Icingadb\Widget;
 use Icinga\Chart\Donut;
 use Icinga\Module\Icingadb\Common\Links;
 use Icinga\Module\Icingadb\Model\HoststateSummary;
+use Icinga\Module\Icingadb\Model\TacticalStateSummary;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
@@ -17,7 +18,6 @@ use ipl\Html\Text;
 use ipl\Stdlib\BaseFilter;
 use ipl\Stdlib\Filter;
 use ipl\Web\Common\Card;
-use ipl\Web\Filter\QueryString;
 
 class HostSummaryDonut extends Card
 {
@@ -25,10 +25,10 @@ class HostSummaryDonut extends Card
 
     protected $defaultAttributes = ['class' => 'donut-container', 'data-base-target' => '_next'];
 
-    /** @var HoststateSummary */
+    /** @var HoststateSummary|TacticalStateSummary */
     protected $summary;
 
-    public function __construct(HoststateSummary $summary)
+    public function __construct(HoststateSummary|TacticalStateSummary $summary)
     {
         $this->summary = $summary;
     }

--- a/library/Icingadb/Widget/ServiceSummaryDonut.php
+++ b/library/Icingadb/Widget/ServiceSummaryDonut.php
@@ -8,6 +8,7 @@ namespace Icinga\Module\Icingadb\Widget;
 use Icinga\Chart\Donut;
 use Icinga\Module\Icingadb\Common\Links;
 use Icinga\Module\Icingadb\Model\ServicestateSummary;
+use Icinga\Module\Icingadb\Model\TacticalStateSummary;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
@@ -24,10 +25,10 @@ class ServiceSummaryDonut extends Card
 
     protected $defaultAttributes = ['class' => 'donut-container', 'data-base-target' => '_next'];
 
-    /** @var ServicestateSummary */
+    /** @var ServicestateSummary|TacticalStateSummary */
     protected $summary;
 
-    public function __construct(ServicestateSummary $summary)
+    public function __construct(ServicestateSummary|TacticalStateSummary $summary)
     {
         $this->summary = $summary;
     }


### PR DESCRIPTION
This introduces a new model `TacticalStateSummary` that represents a union of `HoststateSummary` and `ServicestateSummary`. The union of both is required to have the default export functionality also yield results for both types of states as it only evaluates the first query. Now, CSV/JSON exports also contain service states. Both can be differentiated either by looking at the column data types (`null` for `hosts_*` columns means it's a service state summary) or by simply checking the `type` column which is either `'host_state'` or `'service_state'`.

fixes #1334