### PR TITLE
`CustomvarFlat`: Don't ingnore special chars when splitting

### DIFF
--- a/library/Icingadb/Model/CustomvarFlat.php
+++ b/library/Icingadb/Model/CustomvarFlat.php
@@ -185,7 +185,7 @@ class CustomvarFlat extends Model
                 $path = array_merge(
                     [$realName],
                     $sourcePath
-                        ? preg_split('/(?<=\w|])\.|(?<!^|\.)(?=\[)/', $sourcePath)
+                        ? preg_split('/(?<=.)\.|(?<!^|\.)(?=\[\d+](?:[.\[]|$))/', $sourcePath)
                         : []
                 );
             } else {

--- a/test/php/library/Icingadb/Model/CustomvarFlatTest.php
+++ b/test/php/library/Icingadb/Model/CustomvarFlatTest.php
@@ -53,7 +53,19 @@ class CustomvarFlatTest extends TestCase
         ["real_list[0]","one","real_list","[\"one\",\"two\",\"three\"]"],
         ["[1].2.[3].4.[5].6","123456","[1].2","{\"[3].4\":{\"[5].6\":123456}}"],
         ["ex.ample.com","cba","ex.ample.com","\"cba\""],
-        ["[4]","four","[4]","\"four\""]
+        ["[4]","four","[4]","\"four\""],
+        [
+            "disks.disk /.disk_partitions",
+            "result",
+            "disks",
+            "{\"disk /\":{\"disk_partitions\":\"result\"}}",
+        ],
+        [
+            "test.con[0]cat.foo[1]bar.foo[2]bar",
+            "result",
+            "test",
+            "{\"con[0]cat\":{\"foo[1]bar\":{\"foo[2]bar\":\"result\"}}}",
+        ]
     ];
 
     public const SPECIAL_CHAR_TEST_RESULT = [
@@ -85,7 +97,15 @@ class CustomvarFlatTest extends TestCase
             ]
         ],
         "ex.ample.com" => "cba",
-        "[4]" => "four"
+        "[4]" => "four",
+        "disks" => [
+            "disk /" => ["disk_partitions" => "result"]
+        ],
+        "test" => [
+            "con[0]cat" => [
+                "foo[1]bar" => ["foo[2]bar" => "result"]
+            ]
+        ]
     ];
 
     public function testUnflatteningOfEmptyCustomVariables()


### PR DESCRIPTION
Two issues were fixed in the split regex:

1. Special characters before `.` were ignored:
The old regex only split on `.` when directly preceded by a wordcharacter (\w), causing splits to be missed when `.` was preceded by special characters like whitespace, / or $.
Result before: `foo /.bar.one` => `['foo /.bar', 'one']`
Result after: `foo /.bar.one` => `['foo /', 'bar', 'one']`

2. Brackets mid-word were incorrectly split:
The old regex split before any `[`, causing keys like `con[0]cat` to be split incorrectly.
Now splits before `[` only when it's a standalone array index — meaning `]` is followed by `.`, another `[`, or end of string.
    1. Dot (`.`) : `disk[0].size => ['disk', '[0]', 'size']`
    2. Bracket(`[`): `disk[0][1] => ['disk', '[0]', '[1]']`
    3. String end: `disk[0] => ['disk', '[0]']`

    Result before: `con[0]cat` => `['con', '[0]cat']`
    Result after: `con[0]cat` => `['con', '[0]', 'cat']`
