### PR TITLE
QueryColumnsProvider: Fully use up limit with custom variables

### DIFF
--- a/library/Icingadb/Data/QueryColumnsProvider.php
+++ b/library/Icingadb/Data/QueryColumnsProvider.php
@@ -449,10 +449,17 @@ class QueryColumnsProvider implements IteratorAggregate
 
         $customVars->columns($scalarQueries);
         $customVars->groupBy($idColumn);
-        $customVars->limit(Suggestions::DEFAULT_LIMIT);
 
-        // This outer query exists only because there's no way to combine aggregates and sub queries (yet)
-        return (new Select())->columns($aggregates)->from(['results' => $customVars])->groupBy('flatname');
+        $outerQuery = (new Select())
+            ->columns($aggregates)
+            ->from(['results' => $customVars])
+            ->groupBy('flatname')
+            ->limit(Suggestions::DEFAULT_LIMIT);
+        foreach ($scalarQueries as $name => $_) {
+            $outerQuery->orHaving("MAX($name) = 1");
+        }
+
+        return $outerQuery;
     }
 
     /**


### PR DESCRIPTION
Previously custom variables that didn't match any of the desired sources were eating up the query's limit and so there is a chance that not even a single variable was listed. This especially occurs with the updated notifications integration, as the available database columns are very limited in number. But even in other views this may have been noticed by users in case they have many variables that are similarly named but have no overlap with database columns. (i.e. input that doesn't match any database columns but many vars)