### PR TITLE
`QueryColumnsProvider`: Always quote the relation name

### DIFF
--- a/library/Icingadb/Data/QueryColumnsProvider.php
+++ b/library/Icingadb/Data/QueryColumnsProvider.php
@@ -424,6 +424,8 @@ class QueryColumnsProvider implements IteratorAggregate
                     );
                 }
 
+                $name = $this->getDb()->getAdapter()->quoteIdentifier($name);
+
                 $aggregates[$name] = new Expression("MAX($name)");
                 $scalarQueries[$name] = $select
                     ->resetColumns()->columns(new Expression('1'))


### PR DESCRIPTION
With https://github.com/Icinga/icingadb-web/pull/1377, we introduced a HAVING clause using the MAX function, which require quoting for the reserved keyword (user).

And as we produce sql queries by hand (with ipl-sql) and use strings that were not meant to be used this way, the relation name should always be quoted.