### PR TITLE
Add SLA history relations to Service model

### DIFF
--- a/library/Icingadb/Model/Service.php
+++ b/library/Icingadb/Model/Service.php
@@ -8,6 +8,8 @@ namespace Icinga\Module\Icingadb\Model;
 use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\Common\Backend;
 use ipl\Orm\Behavior\BoolCast;
+use Icinga\Module\Icingadb\Model\SlaHistoryDowntime;
+use Icinga\Module\Icingadb\Model\SlaHistoryState;
 use Icinga\Module\Icingadb\Model\Behavior\HasProblematicParent;
 use Icinga\Module\Icingadb\Model\Behavior\ReRoute;
 use ipl\Orm\Behavior\Binary;
@@ -285,6 +287,8 @@ class Service extends Model
         $relations->hasMany('history', History::class);
         $relations->hasMany('notification', Notification::class)->setJoinType('LEFT');
         $relations->hasMany('notification_history', NotificationHistory::class);
+        $relations->hasMany('sla_history_downtime', SlaHistoryDowntime::class)->setJoinType('LEFT');
+        $relations->hasMany('sla_history_state', SlaHistoryState::class);
 
         $relations->belongsToMany('from', DependencyEdge::class)
             ->setTargetCandidateKey('from_node_id')


### PR DESCRIPTION
Fixes #1386 

Adds `sla_history_downtime` and `sla_history_state` `hasMany` relations to the
`Service` model, mirroring the existing relations already defined in the `Host`
model (added in #1324).

This enables filtering of SLA history through the Service model