### PR TITLE
Fix `SearchControls` trait

### DIFF
--- a/library/Icingadb/Common/SearchControls.php
+++ b/library/Icingadb/Common/SearchControls.php
@@ -9,6 +9,7 @@ use Icinga\Module\Icingadb\Hook\SearchColumnsProviderHook;
 use ipl\Html\Html;
 use ipl\Orm\Query;
 use ipl\Web\Control\SearchBar;
+use ipl\Web\Control\SearchEditor;
 use ipl\Web\Url;
 use ipl\Web\Widget\ContinueWith;
 
@@ -16,6 +17,7 @@ trait SearchControls
 {
     use \ipl\Web\Compat\SearchControls {
         \ipl\Web\Compat\SearchControls::createSearchBar as private webCreateSearchBar;
+        \ipl\Web\Compat\SearchControls::createSearchEditor as private webCreateSearchEditor;
     }
 
     /**
@@ -49,6 +51,20 @@ trait SearchControls
     private function callHandleRequest()
     {
         return false;
+    }
+
+    /**
+     * Necessary because {@see self::callHandleRequest()} prevents the {@see webCreateSearchEditor()} from calling
+     * $editor->handleRequest()
+     *
+     * @inheritdoc
+     */
+    public function createSearchEditor(Query $query, ...$params): SearchEditor
+    {
+        $editor = $this->webCreateSearchEditor($query, ...$params);
+        $editor->handleRequest($this->getServerRequest());
+
+        return $editor;
     }
 
     /**

--- a/library/Icingadb/Common/SearchControls.php
+++ b/library/Icingadb/Common/SearchControls.php
@@ -6,7 +6,6 @@
 namespace Icinga\Module\Icingadb\Common;
 
 use Icinga\Module\Icingadb\Hook\SearchColumnsProviderHook;
-use ipl\Html\Html;
 use ipl\Orm\Query;
 use ipl\Web\Control\SearchBar;
 use ipl\Web\Control\SearchEditor;
@@ -32,11 +31,6 @@ trait SearchControls
     public function createSearchBar(Query $query, ...$params): SearchBar
     {
         $searchBar = $this->webCreateSearchBar($query, ...$params);
-
-        if (($wrapper = $searchBar->getWrapper()) && ! $wrapper->getWrapper()) {
-            // TODO: Remove this once ipl-web v0.7.0 is required
-            $searchBar->addWrapper(Html::tag('div', ['class' => 'search-controls']));
-        }
 
         $model = $query->getModel();
         $defaultColumns = $model->getSearchColumns();

--- a/public/css/common.less
+++ b/public/css/common.less
@@ -107,52 +107,6 @@ div.show-more {
   .notice {
     display: none;
   }
-
-  // TODO: Remove once ipl-web v0.7.0 is required
-  &:not(.default-layout) {
-    .pagination-control {
-      float: left;
-    }
-
-    .sort-control {
-      display: flex;
-      justify-content: flex-end;
-
-      :not(.form-element) > label {
-        margin-right: 0;
-      }
-
-      .control-button {
-        margin: 0;
-      }
-    }
-
-    > :not(:only-child) {
-      margin-bottom: 0.5em;
-    }
-
-    .search-suggestions {
-      margin-bottom: 2.5em;
-    }
-
-    .search-controls {
-      clear: both;
-      display: flex;
-      min-width: 100%;
-
-      .search-bar {
-        flex: 1 1 auto;
-
-        & ~ .control-button:last-child {
-          margin-right: -.5em;
-        }
-
-        & ~ .control-button {
-          margin-left: .5em;
-        }
-      }
-    }
-  }
 }
 
 .content > h2:first-child,


### PR DESCRIPTION
https://github.com/Icinga/icingadb-web/pull/1046 introduced two problems to the `SearchControls` trait.

Returning `false` from `SearchControls::callHandleRequest()` prevents the ipl-web `SearchControls` trait from calling `handleRequest()` in both `createSearchBar()` and `createSearchEditor()`.
An implementation of `createSearchEditor()` is added, which explicitly calls `$editor->handleRequest()` as `createSearchBar()` already does. Without this no `SearchEditor` in the entire module is usable.

An other problem is that moving the call of `$searchbar->handleRequest()` also delayed its `assemble()`, so this if block was entered before the assemble, resulting in the wrapper being added twice.

```
if (($wrapper = $searchBar->getWrapper()) && ! $wrapper->getWrapper()) {
    // TODO: Remove this once ipl-web v0.7.0 is required
    $searchBar->addWrapper(Html::tag('div', ['class' => 'search-controls']));
}
```
which caused a visual bug:

<img width="447" height="175" alt="Screenshot from 2026-06-25 11-01-42" src="https://github.com/user-attachments/assets/4e852585-c677-4c70-8f95-631601294de4" />

The statement should be safe to remove together with the less that has the same `TODO`.