### PR TITLE
Remove data-use-datetime-picker attribute from command forms

### DIFF
--- a/application/forms/Command/Object/AcknowledgeProblemForm.php
+++ b/application/forms/Command/Object/AcknowledgeProblemForm.php
@@ -152,7 +152,6 @@ class AcknowledgeProblemForm extends CommandForm
                 'localDateTime',
                 'expire_time',
                 [
-                    'data-use-datetime-picker'  => true,
                     'required'                  => true,
                     'value'                     => $expireTime,
                     'label'                     => t('Expire Time'),

--- a/application/forms/Command/Object/AddCommentForm.php
+++ b/application/forms/Command/Object/AddCommentForm.php
@@ -108,7 +108,6 @@ class AddCommentForm extends CommandForm
                 'localDateTime',
                 'expire_time',
                 [
-                    'data-use-datetime-picker'  => true,
                     'required'                  => true,
                     'value'                     => $expireTime,
                     'label'                     => t('Expire Time'),

--- a/application/forms/Command/Object/ScheduleCheckForm.php
+++ b/application/forms/Command/Object/ScheduleCheckForm.php
@@ -75,7 +75,6 @@ class ScheduleCheckForm extends CommandForm
             'localDateTime',
             'check_time',
             [
-                'data-use-datetime-picker'  => true,
                 'required'                  => true,
                 'label'                     => t('Check Time'),
                 'description'               => t('Set the date and time when the check should be scheduled.'),

--- a/application/forms/Command/Object/ScheduleServiceDowntimeForm.php
+++ b/application/forms/Command/Object/ScheduleServiceDowntimeForm.php
@@ -120,7 +120,6 @@ class ScheduleServiceDowntimeForm extends CommandForm
             'localDateTime',
             'start',
             [
-                'data-use-datetime-picker'  => true,
                 'required'                  => true,
                 'value'                     => $this->start,
                 'label'                     => t('Start Time'),
@@ -133,7 +132,6 @@ class ScheduleServiceDowntimeForm extends CommandForm
             'localDateTime',
             'end',
             [
-                'data-use-datetime-picker'  => true,
                 'required'                  => true,
                 'label'                     => t('End Time'),
                 'description'               => t('Set the end date and time for the downtime.'),


### PR DESCRIPTION
Flatpickr was a polyfill for browsers lacking native support for `<input type="datetime-local">`, but Firefox and Safari have since added native support, so the polyfill never activates anymore. This follows up on its removal in icingaweb2.

relates to https://github.com/Icinga/icingaweb2/pull/5532