### PR TITLE
Add Configurable Sortcontrols

### DIFF
--- a/library/Icingadb/Web/Controller.php
+++ b/library/Icingadb/Web/Controller.php
@@ -34,12 +34,14 @@ use Icinga\Util\Environment;
 use Icinga\Util\Json;
 use ipl\Html\Html;
 use ipl\Html\ValidHtml;
+use ipl\Orm\Common\SortUtil;
 use ipl\Orm\Query;
 use ipl\Orm\UnionQuery;
 use ipl\Stdlib\Filter;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Control\LimitControl;
 use ipl\Web\Control\PaginationControl;
+use ipl\Web\Control\SortControl;
 use ipl\Web\Filter\QueryString;
 use ipl\Web\FormElement\SearchSuggestions;
 use ipl\Web\Url;
@@ -115,6 +117,77 @@ class Controller extends CompatController
         }
 
         return $chooser;
+    }
+
+    /**
+     * Create and return the SortControl
+     *
+     * Besides the given columns, this also offers the ones configured in `sortcontrols.ini`.
+     *
+     * @param Query                 $query
+     * @param array<string, string> $columns Sort spec to label map
+     *
+     * @return SortControl
+     */
+    public function createSortControl(Query $query, array $columns): SortControl
+    {
+        // Normalize here already, otherwise configured specs won't deduplicate against the built-in ones
+        $normalized = [];
+        foreach ($columns as $spec => $label) {
+            $normalized[SortUtil::normalizeSortSpec($spec)] = $label;
+        }
+
+        // Union, not array_merge: built-in options keep their label and their position
+        $columns = $normalized + $this->fetchConfiguredSortColumns();
+
+        // The parent detects its optional third parameter by argument count, so don't pass it unconditionally
+        return func_num_args() === 3
+            ? parent::createSortControl($query, $columns, func_get_arg(2))
+            : parent::createSortControl($query, $columns);
+    }
+
+    /**
+     * Fetch additional sort columns for the current view from `sortcontrols.ini`
+     *
+     * An entry applies if its `type` matches either the controller name (e.g. `hostgroups`)
+     * or controller and action (e.g. `host/services`).
+     *
+     * @return array<string, string> Sort spec to label map
+     */
+    protected function fetchConfiguredSortColumns(): array
+    {
+        try {
+            $config = Config::module('icingadb', 'sortcontrols');
+        } catch (Exception $e) {
+            Logger::error('Cannot load sortcontrols.ini: %s', $e->getMessage());
+
+            return [];
+        }
+
+        $request = $this->getRequest();
+        $viewKeys = [
+            $request->getControllerName(),
+            $request->getControllerName() . '/' . $request->getActionName()
+        ];
+
+        $columns = [];
+        foreach ($config as $name => $entry) {
+            $types = array_filter(array_map('trim', explode(',', (string) $entry->get('type'))));
+            if (! array_intersect($viewKeys, $types)) {
+                continue;
+            }
+
+            $sort = trim((string) $entry->get('sort'));
+            if ($sort === '') {
+                Logger::warning('Sort control "%s" in sortcontrols.ini has no sort spec, ignoring it', $name);
+
+                continue;
+            }
+
+            $columns[SortUtil::normalizeSortSpec($sort)] = (string) ($entry->get('title') ?: $sort);
+        }
+
+        return $columns;
     }
 
     /**


### PR DESCRIPTION
Add custom sort controls to a host/service/hostgroup/servicegroup/... based on an ini file.

This avoids having to patch the controller source code with extra custom lines on every icingadb-web upgrade.

; Extra sort options for Icinga DB Web list views.
;
; Location:  /etc/icingaweb2/modules/icingadb/sortcontrols.ini
; Ownership: root:icingaweb2, mode 0660 (must be readable by the web server user)
;
; One section per sort option. The section name is only an identifier and must be
; unique within this file; it is never shown in the UI. Prefixing it with the view
; keeps related options together.
;
;   type   Comma separated list of views this option applies to. Either a controller
;          name (hosts, services, hostgroups, servicegroups, comments, downtimes,
;          notifications, contacts, contactgroups, history) or controller/action for
;          the lists inside a detail view (host/services, host/history, host/parents,
;          host/children, service/history, hostgroup/hosts, servicegroup/services).
;   sort   The full sort spec, exactly as it would appear in the ?sort= URL parameter.
;          Multiple columns are allowed, separated by commas.
;   title  Label shown in the "Sort By" dropdown. Optional; defaults to the sort spec.
;          Not translatable, since it does not end up in the .po catalogs.
;
; Options appear in the dropdown in the order they are listed here, after the ones
; that ship with the module.

; Example

[hostgroups_srv_critical_warning_unhandled]
type  = "hostgroups"
sort  = "services_critical_unhandled desc,services_warning_unhandled desc"
title = "Srv Unhandled Critial,Warning"


