### PR TITLE
CommandActions: Pass a query's result set instead as objects

### DIFF
--- a/library/Icingadb/Common/CommandActions.php
+++ b/library/Icingadb/Common/CommandActions.php
@@ -162,7 +162,12 @@ trait CommandActions
             $form = new $form();
         }
 
-        $form->setObjects($this->getCommandTargets());
+        $objects = $this->getCommandTargets();
+        if (! is_array($objects)) {
+            $objects = $objects->execute();
+        }
+
+        $form->setObjects($objects);
 
         if (! $isApi || $isXhr) {
             $this->handleWebRequest($form);


### PR DESCRIPTION
This effectively makes it impossible to accidentally issue the query over and over.

refs #1392
requires https://github.com/Icinga/ipl-orm/issues/168